### PR TITLE
KDP Software Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Feedback and bug reports are welcome and may be posted on the
 ### Installing Docker
 
 The KIM Developer Platform is distributed on the Github Container Registry as
-a Docker image.  See
+a docker image.  In order to use it, you will need to install docker.  See
 [https://docs.docker.com/get-docker/](https://docs.docker.com/get-docker/) for
-instructions on installing Docker Desktop for your platform.  If using macOS or
+instructions on installing Docker Desktop for your OS.  If using macOS or
 Windows, remember to start the Docker Desktop application before attempting to
 use any `docker` commands.
 
@@ -51,21 +51,25 @@ while all of the containers created from your local images can be viewed with
 running).  You can view the size of the containers you have created by doing
 `docker ps -as`.
 
-## Installing images from this repository
+## Images hosted in this repository
 
 There are two images published with each release of the KDP: a "full" image and
 a "minimal" image.  The former image contains all of the packages necessary to
 run all KIM tests and verification checks, while the latter includes a set of
 packages sufficient to run most of them but not all.  In particular, the
 biggest difference at the moment is that the full image contains an
-installation of [OVITO](https://www.ovito.org/), which doubles the uncompressed size of the
-image from roughly 1.04GB ➝ 2.04GB; this package is currently only used to run
-the dislocation tests, so for most users the minimal images will suffice.
+installation of [OVITO](https://www.ovito.org/), which doubles the uncompressed
+size of the image from roughly 1.04GB ➝ 2.04GB; this package is currently only
+used to run the dislocation tests, so for most users the minimal images will
+suffice.
 
-## Creating a container from the image
+## Installing the KIM Developer Platform
 
-To create a container from the latest image, you must first pull the image
-itself.   If you want the latest minimal image, you must explicitly specify a
+Once docker is installed, there are two remaining steps in setting up the KIM
+Developer Platform: (1) pulling one of the images hosted in this repository,
+and (2) spawning a container from the image.  As mentioned above, the former is
+accomplished using `docker pull`, while the latter can be done with `docker
+run`.  If you want the latest minimal image, you must explicitly specify a
 corresponding docker tag ending in '-minimal' (replacing `kim_dev` with
 whatever name you wish to use for the container on your system):
 ```

--- a/docker/config/Dockerfile
+++ b/docker/config/Dockerfile
@@ -48,7 +48,7 @@ COPY utils/pipeline-run-matches /usr/local/bin/
 COPY utils/pipeline-run-pair /usr/local/bin/
 COPY utils/pipeline-run-tests /usr/local/bin/
 COPY utils/pipeline-run-verification-checks /usr/local/bin/
-COPY utils/testgenie /usr/local/bin/
+COPY utils/kimgenie /usr/local/bin/
 
 # Create local repository directory structure
 ENV LOCAL_REPOSITORY_ROOT=/home/openkim/

--- a/docker/config/Dockerfile
+++ b/docker/config/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2018-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/compute.py
+++ b/docker/config/excerpts/compute.py
@@ -3,7 +3,7 @@ Contains the tools required to perform a pipeline computation.  The main object
 is Computation, which takes a runner and subject and runs them against each
 other
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.
@@ -151,6 +151,7 @@ class Command:
 
                     if not readable:
                         # This OutStream is finished
+                        os.close(file_desc.fileno())
                         file_descriptors.remove(file_desc)
 
         else:

--- a/docker/config/excerpts/config.py
+++ b/docker/config/excerpts/config.py
@@ -219,6 +219,7 @@ item_subdir_names = {}
 if conf.get("USE_FULL_ITEM_NAMES_IN_REPO"):
     item_subdir_names["md"] = "model-drivers"
     item_subdir_names["mo"] = "models"
+    item_subdir_names["rd"] = "reference-data"
     item_subdir_names["sm"] = "simulator-models"
     item_subdir_names["td"] = "test-drivers"
     item_subdir_names["te"] = "tests"
@@ -230,6 +231,7 @@ if conf.get("USE_FULL_ITEM_NAMES_IN_REPO"):
 else:
     item_subdir_names["md"] = "md"
     item_subdir_names["mo"] = "mo"
+    item_subdir_names["rd"] = "rd"
     item_subdir_names["sm"] = "sm"
     item_subdir_names["td"] = "td"
     item_subdir_names["te"] = "te"

--- a/docker/config/excerpts/config.py
+++ b/docker/config/excerpts/config.py
@@ -9,7 +9,7 @@ and this module is imported in star from at the top of all of the scripts::
 
     import config as cf
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/default-environment
+++ b/docker/config/excerpts/default-environment
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/kimcodes.py
+++ b/docker/config/excerpts/kimcodes.py
@@ -1,7 +1,7 @@
 """
 This module is intended to handle anything related to KIM IDs, uuids, or jobids.
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/kimobjects.py
+++ b/docker/config/excerpts/kimobjects.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/kimquery.py
+++ b/docker/config/excerpts/kimquery.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/kimunits.py
+++ b/docker/config/excerpts/kimunits.py
@@ -1,7 +1,7 @@
 """
 Simple wrapper for executable for converting arbitrary units to SI units
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/local_search.py
+++ b/docker/config/excerpts/local_search.py
@@ -5,7 +5,7 @@ database because only actual test results are inserted into it, i.e. it has a
 'data' collection but not an 'obj' collection like the production mongo does.
 It works by simply using glob patterns, similar
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/matching.py
+++ b/docker/config/excerpts/matching.py
@@ -2,7 +2,7 @@
 Methods for determining whether a Test or Verification Check can run against a
 Model or Simulator Model.
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/mongodb.py
+++ b/docker/config/excerpts/mongodb.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/query_local/helper_functions.py
+++ b/docker/config/excerpts/query_local/helper_functions.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/query_local/queryapi.py
+++ b/docker/config/excerpts/query_local/queryapi.py
@@ -51,7 +51,7 @@ output parameters.
    listed in the method table next to their corresponding test driver KIM ID
    separated by a vertical bar (|).
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/template.py
+++ b/docker/config/excerpts/template.py
@@ -18,7 +18,7 @@ are available
         one unit to another
     * asedata - the dictionary of reference data contained within ASE
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/excerpts/util.py
+++ b/docker/config/excerpts/util.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/instructions/README.txt
+++ b/docker/config/instructions/README.txt
@@ -4,7 +4,7 @@ Your sudo password is the same as your user name: "openkim"
 
 Comments/questions/bug reports are appreciated and can be sent to support@openkim.org.
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This file may be distributed as-is, without modification.

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -199,9 +199,7 @@ class ItemGenerator:
         else:
             return template_file_name
 
-    def _move_rendered_item_to_final_destination(
-        self
-    ):
+    def _move_rendered_item_to_final_destination(self):
         # Now move the finished item directory to its final home
         item_dest = self.item_destination_path
         if os.path.isdir(item_dest):
@@ -211,8 +209,7 @@ class ItemGenerator:
                 shutil.move(self.tmp_item_dir, item_dest)
             else:
                 raise OSError(
-                    "Directory {} already exists! "
-                    "Aborting...".format(item_dest)
+                    "Directory {} already exists! Aborting...".format(item_dest)
                 )
         else:
             shutil.move(self.tmp_item_dir, item_dest)
@@ -246,15 +243,15 @@ class ItemGenerator:
                 self.template_variables.update({"kimspec": kimspeckeys})
                 self.template_variables.update({"query": _query_stub})
 
-                item_name = self.template_variables["kimspec"][
+                self.item_name = self.template_variables["kimspec"][
                     self._item_name_kimspec_key
                 ]
 
                 # Copy template file directory to temporary directory
-                self.tmp_item_dir = os.path.join(tempdir, item_name)
+                self.tmp_item_dir = os.path.join(tempdir, self.item_name)
                 shutil.copytree(self.template_file_directory_path, self.tmp_item_dir)
 
-                self.logger.info("BUILDING: %s @ %s", item_name, self.tmp_item_dir)
+                self.logger.info("BUILDING: %s @ %s", self.item_name, self.tmp_item_dir)
                 self.logger.debug("Variable_dict: %s", self.template_variables)
 
                 for (basepath, _, files) in os.walk(self.tmp_item_dir):
@@ -314,11 +311,12 @@ class ItemGenerator:
                         # Set permissions to match the corresponding template file
                         os.chmod(newfilepath, original_mode)
 
-                self.item_destination_path = os.path.join(destination, item_name)
+                self.item_destination_path = os.path.join(
+                    self.destination, self.item_name
+                )
 
                 if not self.dry_run:
-                    self._move_rendered_item_to_final_destination(
-                    )
+                    self._move_rendered_item_to_final_destination()
 
         except KeyboardInterrupt:
             sys.exit(1)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -112,8 +112,8 @@ FILENAME_REGEX = re.compile(
 
 
 def maketest(
-    folder,
-    variable_dict,
+    directory,
+    template_variables,
     dest=TEDIR,
     overwrite=False,
     dry_run=False,
@@ -121,7 +121,7 @@ def maketest(
     filename_extension=None,
     logger=None,
 ):
-    """Make a Test given the input folder"""
+    """Make a Test given the input directory"""
 
     def query_stub(x):
         """Render everything inside the argument to the query function, then
@@ -129,7 +129,7 @@ def maketest(
         be made"""
         tmp_env = jinja2.Environment(loader=jinja2.BaseLoader).from_string(str(x))
         tmp_env.globals.update({"stripversion": kimcodes.strip_version})
-        rendered = tmp_env.render(**variable_dict)
+        rendered = tmp_env.render(**template_variables)
         return f"{{{{ query({rendered}) }}}}"
 
     if logger is None:
@@ -142,27 +142,27 @@ def maketest(
         # First parse the kimspec file
         KIMSPEC_FILE_TEMP = KIMSPEC_FILE + ".genie"
 
-        file_newconf = os.path.join(folder, KIMSPEC_FILE_TEMP)
+        file_newconf = os.path.join(directory, KIMSPEC_FILE_TEMP)
         kimspec_template = template_environment.get_template(file_newconf)
-        kimspec = kimspec_template.render(**variable_dict)
+        kimspec = kimspec_template.render(**template_variables)
 
         with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
             f.write(kimspec)
 
-        # Extend variable_dict with everything defined in kimspec
+        # Extend template_variables with everything defined in kimspec
         kimspeckeys = edn_format.loads(kimspec, write_ply_tables=False)
-        variable_dict.update({"kimspec": kimspeckeys})
-        variable_dict.update({"query": query_stub})
+        template_variables.update({"kimspec": kimspeckeys})
+        template_variables.update({"query": query_stub})
 
         # Get Test name from kimspec
-        test_name = variable_dict["kimspec"]["extended-id"]
+        test_name = template_variables["kimspec"]["extended-id"]
 
         # Create temporary directory
         tmp_test_dir = os.path.join(tempdir, test_name)
-        shutil.copytree(folder, tmp_test_dir)
+        shutil.copytree(directory, tmp_test_dir)
 
         logger.info("BUILDING: {} @ {}".format(test_name, tmp_test_dir))
-        logger.debug("Variable_dict: {}".format(variable_dict))
+        logger.debug("Variable_dict: {}".format(template_variables))
 
         for (basepath, _, files) in os.walk(tmp_test_dir):
             for fl in files:
@@ -189,7 +189,7 @@ def maketest(
                 if filename_search:
                     filename_template = FILENAME_REGEX.search(contents).group(1)
                     filename = jinja2.Template(filename_template).render(
-                        **variable_dict
+                        **template_variables
                     )
 
                 logger.debug("new file name: {}".format(filename))
@@ -197,7 +197,7 @@ def maketest(
                 # Template everything completely other than query calls, for which we only template
                 # the arguments for now
                 template_intermediate = template_environment.get_template(filepath)
-                new_contents = template_intermediate.render(**variable_dict)
+                new_contents = template_intermediate.render(**template_variables)
 
                 # Now actually perform any queries that might be present and write the final rendered
                 # template to file
@@ -301,7 +301,7 @@ if __name__ == "__main__":
         "--destination",
         type=str,
         default=TEDIR,
-        help="Destination folder for generated Tests [default: {}]".format(TEDIR),
+        help="Destination directory for generated Tests [default: {}]".format(TEDIR),
     )
 
     parser.add_argument(
@@ -428,7 +428,8 @@ if __name__ == "__main__":
         except Exception:
             global_vars = json.loads(global_path)
 
-    # If user provided add-random-kimnums option, attempt to overwrite their generator file
+    # If user provided add-random-kimnums option, attempt to overwrite their
+    # generator file
     if random_codes:
         generator_file_dicts = []
         # First, read generator file and ensure there are no 'kimnum' entries
@@ -464,11 +465,11 @@ if __name__ == "__main__":
         os.path.join(td_template_path, "..", generator_file), encoding="utf-8"
     ) as f:
         for line in f:
-            variable_dict = global_vars.copy()
-            variable_dict.update(json.loads(line))
+            template_variables = global_vars.copy()
+            template_variables.update(json.loads(line))
             newtestpath = maketest(
                 td_template_path,
-                variable_dict=variable_dict,
+                template_variables=template_variables,
                 dest=dest,
                 overwrite=overwrite,
                 dry_run=dry_run,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -449,27 +449,6 @@ def create_shared_arguments():
     shared = argparse.ArgumentParser(add_help=False)
 
     shared.add_argument(
-        "--global-variables-file",
-        type=str,
-        help="Additional JSON-formatted dictionary of global variables, as file or string",
-    )
-
-    shared.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Don't actually create the items, but rather just show what would be generated",
-    )
-
-    shared.add_argument(
-        "--overwrite",
-        action="store_true",
-        help=(
-            "Overwrite any existing item directories which already exist at the locations where "
-            "the Tests being generated are trying to be written to. Use with caution!"
-        ),
-    )
-
-    shared.add_argument(
         "--add-random-kimnums",
         action="store_true",
         help=(
@@ -484,12 +463,9 @@ def create_shared_arguments():
     )
 
     shared.add_argument(
-        "--filename-prefix",
-        type=str,
-        help=(
-            "File name prefix; only files with the specified prefix are "
-            "included in the rendered item directories."
-        ),
+        "--dry-run",
+        action="store_true",
+        help="Don't actually create the items, but rather just show what would be generated",
     )
 
     shared.add_argument(
@@ -499,6 +475,46 @@ def create_shared_arguments():
             "File name extension; only files with the specified extension are "
             "included in the rendered item directories."
         ),
+    )
+
+    shared.add_argument(
+        "--filename-prefix",
+        type=str,
+        help=(
+            "File name prefix; only files with the specified prefix are "
+            "included in the rendered item directories."
+        ),
+    )
+
+    shared.add_argument(
+        "--global-variables-file",
+        type=str,
+        help="Additional JSON-formatted dictionary of global variables, as file or string",
+    )
+
+    shared.add_argument(
+        "--log-file",
+        type=str,
+        help=(
+            "Name of file to write logs to. If left unspecified, logs are not written "
+            "(although the list of generated items is still printed to the terminal)."
+        ),
+    )
+
+    shared.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Overwrite any existing item directories which already exist at the locations where "
+            "the Tests being generated are trying to be written to. Use with caution!"
+        ),
+    )
+
+    shared.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show debugging messages and timestamps in logs",
     )
 
     shared.add_argument(
@@ -513,34 +529,18 @@ def create_shared_arguments():
         ),
     )
 
-    shared.add_argument(
-        "--log-file",
-        type=str,
-        help=(
-            "Name of file to write logs to. If left unspecified, logs are not written "
-            "(although the list of generated items is still printed to the terminal)."
-        ),
-    )
-
-    shared.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Show debugging messages and timestamps in logs",
-    )
-
     return shared
 
 
 def create_tests_arguments(parse_tests):
+
+    default_destination = DEFAULT_DESTINATION_TESTS
     parse_tests.add_argument(
-        "--test-driver",
+        "--destination",
         type=str,
-        help=(
-            "Extended KIM ID of the Test Driver whose Tests you wish to "
-            "generate.  Either this option or the 'root-dir' option should be "
-            "given.  If this option is specified, the corresponding Test "
-            f"Driver directory must exist under {TDDIR}."
+        default=default_destination,
+        help="Destination directory for generated items [default: {}]".format(
+            default_destination
         ),
     )
 
@@ -560,16 +560,6 @@ def create_tests_arguments(parse_tests):
         "'test-driver' option must be given.",
     )
 
-    default_destination = DEFAULT_DESTINATION_TESTS
-    parse_tests.add_argument(
-        "--destination",
-        type=str,
-        default=default_destination,
-        help="Destination directory for generated items [default: {}]".format(
-            default_destination
-        ),
-    )
-
     default_template_dir = DEFAULT_TEMPLATE_DIR_TESTS
     parse_tests.add_argument(
         "--template-dir",
@@ -580,16 +570,28 @@ def create_tests_arguments(parse_tests):
         ),
     )
 
+    parse_tests.add_argument(
+        "--test-driver",
+        type=str,
+        help=(
+            "Extended KIM ID of the Test Driver whose Tests you wish to "
+            "generate.  Either this option or the 'root-dir' option should be "
+            "given.  If this option is specified, the corresponding Test "
+            f"Driver directory must exist under {TDDIR}."
+        ),
+    )
+
 
 def create_ref_data_arguments(parse_ref_data):
     # TODO: Reduce duplication in creation of args that are essentially shared
     # with the 'tests' mode but simply have different default values
+    default_destination = DEFAULT_DESTINATION_REFDATA
     parse_ref_data.add_argument(
-        "root-dir",
+        "--destination",
         type=str,
-        help=(
-            "The directory that contains the template file directory and "
-            "generator file.  May be an absolute or relative path."
+        default=default_destination,
+        help="Destination directory for generated items [default: {}]".format(
+            default_destination
         ),
     )
 
@@ -601,13 +603,12 @@ def create_ref_data_arguments(parse_ref_data):
         help=f"Generator file [default: {default_generator_file}]",
     )
 
-    default_destination = DEFAULT_DESTINATION_REFDATA
     parse_ref_data.add_argument(
-        "--destination",
+        "root-dir",
         type=str,
-        default=default_destination,
-        help="Destination directory for generated items [default: {}]".format(
-            default_destination
+        help=(
+            "The directory that contains the template file directory and "
+            "generator file.  May be an absolute or relative path."
         ),
     )
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -430,7 +430,16 @@ if __name__ == "__main__":
     parse_tests.set_defaults(action="tests")
     parse_ref_data.set_defaults(action="ref-data")
 
+    # Pull args passed on command line
     args = vars(parser.parse_args())
+
+    dest = args["destination"]
+    overwrite = args["overwrite"]
+    dry_run = args["dry_run"]
+    random_codes = args["add_random_kimnums"]
+    generator_file = args["generator_file"]
+    filename_prefix = args["filename_prefix"]
+    filename_extension = args["filename_extension"]
 
     global_vars = {}
 
@@ -465,15 +474,6 @@ if __name__ == "__main__":
 
     # Set up logger if necessary
     logger = setup_logging(args["logfile"], args["verbose"])
-
-    # Destination directory
-    dest = args["destination"]
-    overwrite = args["overwrite"]
-    dry_run = args["dry_run"]
-    random_codes = args["add_random_kimnums"]
-    generator_file = args["generator_file"]
-    filename_prefix = args["filename_prefix"]
-    filename_extension = args["filename_extension"]
 
     # Expand ~ to home directory in dest
     dest = re.sub("~", os.path.expanduser("~"), dest)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -140,112 +140,111 @@ def generate_item(
         logger.addHandler(nullhdlr)
 
     try:
-        tempdir = tempfile.mkdtemp()
-        # First parse the kimspec file
-        KIMSPEC_FILE_TEMP = KIMSPEC_FILE + ".genie"
+        with tempfile.TemporaryDirectory() as tempdir:
 
-        file_newconf = os.path.join(directory, KIMSPEC_FILE_TEMP)
-        kimspec_template = template_environment.get_template(file_newconf)
-        kimspec = kimspec_template.render(**template_variables)
+            # First parse the kimspec file
+            KIMSPEC_FILE_TEMP = KIMSPEC_FILE + ".genie"
 
-        with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
-            f.write(kimspec)
+            file_newconf = os.path.join(directory, KIMSPEC_FILE_TEMP)
+            kimspec_template = template_environment.get_template(file_newconf)
+            kimspec = kimspec_template.render(**template_variables)
 
-        # Extend template_variables with everything defined in kimspec
-        kimspeckeys = kim_edn.loads(kimspec)
-        template_variables.update({"kimspec": kimspeckeys})
-        template_variables.update({"query": query_stub})
+            with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
+                f.write(kimspec)
 
-        # Get Test name from kimspec
-        test_name = template_variables["kimspec"]["extended-id"]
+            # Extend template_variables with everything defined in kimspec
+            kimspeckeys = kim_edn.loads(kimspec)
+            template_variables.update({"kimspec": kimspeckeys})
+            template_variables.update({"query": query_stub})
 
-        # Create temporary directory
-        tmp_test_dir = os.path.join(tempdir, test_name)
-        shutil.copytree(directory, tmp_test_dir)
+            # Get Test name from kimspec
+            test_name = template_variables["kimspec"]["extended-id"]
 
-        logger.info("BUILDING: {} @ {}".format(test_name, tmp_test_dir))
-        logger.debug("Variable_dict: {}".format(template_variables))
+            # Create temporary directory
+            tmp_test_dir = os.path.join(tempdir, test_name)
+            shutil.copytree(directory, tmp_test_dir)
 
-        for (basepath, _, files) in os.walk(tmp_test_dir):
-            for fl in files:
-                logger.debug("processing {}".format(fl))
-                filepath = os.path.join(basepath, fl)
-                with open(filepath, encoding="utf-8") as f:
-                    contents = f.read()
-                # copy original mode so we can chmod at end
-                original_mode = os.stat(filepath).st_mode
-                filename = fl
-                if filename_prefix:
-                    if not filename.startswith(filename_prefix):
-                        os.remove(filepath)
-                        continue
+            logger.info("BUILDING: {} @ {}".format(test_name, tmp_test_dir))
+            logger.debug("Variable_dict: {}".format(template_variables))
+
+            for (basepath, _, files) in os.walk(tmp_test_dir):
+                for fl in files:
+                    logger.debug("processing {}".format(fl))
+                    filepath = os.path.join(basepath, fl)
+                    with open(filepath, encoding="utf-8") as f:
+                        contents = f.read()
+                    # copy original mode so we can chmod at end
+                    original_mode = os.stat(filepath).st_mode
+                    filename = fl
+                    if filename_prefix:
+                        if not filename.startswith(filename_prefix):
+                            os.remove(filepath)
+                            continue
+                        else:
+                            filename = filename[len(filename_prefix) :]
+                    if filename_extension:
+                        if not filename.endswith(filename_extension):
+                            os.remove(filepath)
+                            continue
+                        else:
+                            filename = filename[: -len(filename_extension) - 1]
+                    filename_search = FILENAME_REGEX.search(contents)
+                    if filename_search:
+                        filename_template = FILENAME_REGEX.search(contents).group(1)
+                        filename = jinja2.Template(filename_template).render(
+                            **template_variables
+                        )
+
+                    logger.debug("new file name: {}".format(filename))
+
+                    # Template everything completely other than query calls, for which we only template
+                    # the arguments for now
+                    template_intermediate = template_environment.get_template(filepath)
+                    new_contents = template_intermediate.render(**template_variables)
+
+                    # Now actually perform any queries that might be present and
+                    # write the final rendered template to file
+                    template_final = jinja2.Environment(
+                        loader=jinja2.BaseLoader
+                    ).from_string(str(new_contents))
+                    new_contents = template_final.render({"query": kimquery.query})
+
+                    newfilepath = os.path.join(basepath, filename)
+                    os.remove(filepath)
+
+                    with open(newfilepath, "w", encoding="utf-8") as g:
+                        g.write(new_contents)
+                    # Set permissions to match the corresponding template file
+                    os.chmod(newfilepath, original_mode)
+
+            test_dest_name = os.path.join(dest, test_name)
+
+            if not dry_run:
+                # Now move the finished Test directory to its final home
+                if os.path.isdir(test_dest_name):
+                    logger.info("Moving to {}".format(test_dest_name))
+                    if overwrite:
+                        shutil.rmtree(test_dest_name)
+                        shutil.move(tmp_test_dir, test_dest_name)
                     else:
-                        filename = filename[len(filename_prefix) :]
-                if filename_extension:
-                    if not filename.endswith(filename_extension):
-                        os.remove(filepath)
-                        continue
-                    else:
-                        filename = filename[: -len(filename_extension) - 1]
-                filename_search = FILENAME_REGEX.search(contents)
-                if filename_search:
-                    filename_template = FILENAME_REGEX.search(contents).group(1)
-                    filename = jinja2.Template(filename_template).render(
-                        **template_variables
-                    )
-
-                logger.debug("new file name: {}".format(filename))
-
-                # Template everything completely other than query calls, for which we only template
-                # the arguments for now
-                template_intermediate = template_environment.get_template(filepath)
-                new_contents = template_intermediate.render(**template_variables)
-
-                # Now actually perform any queries that might be present and
-                # write the final rendered template to file
-                template_final = jinja2.Environment(
-                    loader=jinja2.BaseLoader
-                ).from_string(str(new_contents))
-                new_contents = template_final.render({"query": kimquery.query})
-
-                newfilepath = os.path.join(basepath, filename)
-                os.remove(filepath)
-
-                with open(newfilepath, "w", encoding="utf-8") as g:
-                    g.write(new_contents)
-                # Set permissions to match the corresponding template file
-                os.chmod(newfilepath, original_mode)
-
-        test_dest_name = os.path.join(dest, test_name)
-
-        if not dry_run:
-            # Now move the finished Test directory to its final home
-            if os.path.isdir(test_dest_name):
-                logger.info("Moving to {}".format(test_dest_name))
-                if overwrite:
-                    shutil.rmtree(test_dest_name)
-                    shutil.move(tmp_test_dir, test_dest_name)
+                        shutil.rmtree(tempdir)
+                        raise OSError(
+                            "Directory {} already exists! "
+                            "Aborting...".format(test_dest_name)
+                        )
                 else:
-                    shutil.rmtree(tempdir)
-                    raise OSError(
-                        "Directory {} already exists! "
-                        "Aborting...".format(test_dest_name)
-                    )
-            else:
-                shutil.move(tmp_test_dir, test_dest_name)
+                    shutil.move(tmp_test_dir, test_dest_name)
+
+                # Clean up
+                shutil.rmtree(tempdir)
+
+                return os.path.join(dest, test_name)
 
             # Clean up
             shutil.rmtree(tempdir)
-
-            return os.path.join(dest, test_name)
-
-        # Clean up
-        shutil.rmtree(tempdir)
-        return test_dest_name
+            return test_dest_name
 
     except KeyboardInterrupt:
-        # Make sure we clean up our temporary directory if the user interrupts the process
-        shutil.rmtree(tempdir)
         sys.exit(1)
 
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -379,7 +379,7 @@ def create_shared_arguments():
     )
 
     shared.add_argument(
-        "--logfile",
+        "--log-file",
         type=str,
         help=(
             "Name of file to write logs to. If left unspecified, logs are not written "
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
     global_variables_file = args["global_variables"]
-    logfile = args["logfile"]
+    log_file = args["log_file"]
     verbose = args["verbose"]
     version = args["version"]
     template_files_dir = args["template_dir"]
@@ -507,7 +507,7 @@ if __name__ == "__main__":
     template_environment.globals.update({"stripversion": kimcodes.strip_version})
 
     # Set up logger if necessary
-    logger = setup_logging(logfile, verbose)
+    logger = setup_logging(log_file, verbose)
 
     # Expand ~ to home directory in dest
     dest = re.sub("~", os.path.expanduser("~"), dest)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -71,9 +71,20 @@ import excerpts.config as cf
 
 
 TDDIR = os.path.join(cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["td"])
-TEDIR = os.path.join(cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["te"])
+
 KIMSPEC_FILE = cf.CONFIG_FILE
-TEMPLATEDIR = "test_template"
+
+DEFAULT_GENERATOR_FILE_TESTS = "test_generator.json"
+DEFAULT_GENERATOR_FILE_REFDATA = "refdata_generator.json"
+DEFAULT_TEMPLATE_DIR_TESTS = "test_template"
+DEFAULT_TEMPLATE_DIR_REFDATA = "refdata_template"
+
+DEFAULT_DESTINATION_TESTS = os.path.join(
+    cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["te"]
+)
+DEFAULT_DESTINATION_REFDATA = os.path.join(
+    cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["rd"]
+)
 
 
 class IncompatibleArgumentCombination(Exception):
@@ -127,7 +138,7 @@ def generate_item(
     mode,
     template_file_directory_path,
     template_variables,
-    dest=TEDIR,
+    dest,
     overwrite=False,
     dry_run=False,
     filename_prefix=None,
@@ -337,22 +348,6 @@ def create_shared_arguments():
     shared = argparse.ArgumentParser(add_help=False)
 
     shared.add_argument(
-        "--template-dir",
-        type=str,
-        default=TEMPLATEDIR,
-        help="Directory containing the template files [default: {}]".format(
-            TEMPLATEDIR
-        ),
-    )
-
-    shared.add_argument(
-        "--generator-file",
-        type=str,
-        default="test_generator.json",
-        help="Generator file [default: test_generator.json]",
-    )
-
-    shared.add_argument(
         "--global-variables",
         type=str,
         help="Additional JSON-formatted dictionary of global variables, as file or string",
@@ -362,13 +357,6 @@ def create_shared_arguments():
         "--dry-run",
         action="store_true",
         help="Don't actually create the items, but rather just show what would be generated",
-    )
-
-    shared.add_argument(
-        "--destination",
-        type=str,
-        default=TEDIR,
-        help="Destination directory for generated items [default: {}]".format(TEDIR),
     )
 
     shared.add_argument(
@@ -454,6 +442,15 @@ def create_tests_arguments(parse_tests):
             f"Driver directory must exist under {TDDIR}."
         ),
     )
+
+    default_generator_file = DEFAULT_GENERATOR_FILE_TESTS
+    parse_tests.add_argument(
+        "--generator-file",
+        type=str,
+        default=default_generator_file,
+        help=f"Generator file [default: {default_generator_file}]",
+    )
+
     parse_tests.add_argument(
         "--root-dir",
         type=str,
@@ -462,14 +459,64 @@ def create_tests_arguments(parse_tests):
         "'test-driver' option must be given.",
     )
 
+    default_destination = DEFAULT_DESTINATION_TESTS
+    parse_tests.add_argument(
+        "--destination",
+        type=str,
+        default=default_destination,
+        help="Destination directory for generated items [default: {}]".format(
+            default_destination
+        ),
+    )
+
+    default_template_dir = DEFAULT_TEMPLATE_DIR_TESTS
+    parse_tests.add_argument(
+        "--template-dir",
+        type=str,
+        default=default_template_dir,
+        help="Directory containing the template files [default: {}]".format(
+            default_template_dir
+        ),
+    )
+
 
 def create_ref_data_arguments(parse_ref_data):
+    # TODO: Reduce duplication in creation of args that are essentially shared
+    # with the 'tests' mode but simply have different default values
     parse_ref_data.add_argument(
         "root-dir",
         type=str,
         help=(
             "The directory that contains the template file directory and "
             "generator file.  May be an absolute or relative path."
+        ),
+    )
+
+    default_generator_file = DEFAULT_GENERATOR_FILE_REFDATA
+    parse_ref_data.add_argument(
+        "--generator-file",
+        type=str,
+        default=default_generator_file,
+        help=f"Generator file [default: {default_generator_file}]",
+    )
+
+    default_destination = DEFAULT_DESTINATION_REFDATA
+    parse_ref_data.add_argument(
+        "--destination",
+        type=str,
+        default=default_destination,
+        help="Destination directory for generated items [default: {}]".format(
+            default_destination
+        ),
+    )
+
+    default_template_dir = DEFAULT_TEMPLATE_DIR_REFDATA
+    parse_ref_data.add_argument(
+        "--template-dir",
+        type=str,
+        default=default_template_dir,
+        help="Directory containing the template files [default: {}]".format(
+            default_template_dir
         ),
     )
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -550,7 +550,12 @@ def create_tests_arguments(parse_tests):
         "--generator-file",
         type=str,
         default=default_generator_file,
-        help=f"Generator file [default: {default_generator_file}]",
+        help=(
+            "A file where each line is a JSON-formatted dictionary used to "
+            "create a template variable namespace to apply to the files in "
+            "the template file directory in order to generate an item. "
+            f"[default: {default_generator_file}]"
+        ),
     )
 
     parse_tests.add_argument(
@@ -601,7 +606,12 @@ def create_ref_data_arguments(parse_ref_data):
         "--generator-file",
         type=str,
         default=default_generator_file,
-        help=f"Generator file [default: {default_generator_file}]",
+        help=(
+            "A file where each line is a JSON-formatted dictionary used to "
+            "create a template variable namespace to apply to the files in "
+            "the template file directory in order to generate an item. "
+            f"[default: {default_generator_file}]"
+        ),
     )
 
     parse_ref_data.add_argument(

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -545,9 +545,9 @@ if __name__ == "__main__":
         sys.exit(0)
 
     elif action == "tests":
-        root_dir = args["root_dir"]
-        test_driver = args["test_driver"]
-        process_tests_root_dir_and_test_driver_options(root_dir, test_driver)
+        root_dir, test_driver = process_tests_root_dir_and_test_driver_options(
+            args["root_dir"], args["test_driver"]
+        )
         if test_driver:
             global_template_vars["TEST_DRIVER_NAME"] = test_driver
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -53,6 +53,7 @@ reserved.
 
 This software may be distributed as-is, without modification.
 """
+from abc import abstractmethod
 import logging
 import logging.handlers
 import os
@@ -109,203 +110,236 @@ def createLogger(logfile, verbose):
     return logger
 
 
-################################
-# Primary Test factory function
-################################
-FILENAME_REGEX = re.compile(
-    r"""
-    FILENAME    # magic word
-    \s*         # whitespace
-    =           # equal character
-    \s*         # whitespace
-    (\S+)       # name
-    """,
-    re.VERBOSE,
-)
+class ItemGenerator:
 
+    FILENAME_REGEX = re.compile(
+        r"""
+        FILENAME    # magic word
+        \s*         # whitespace
+        =           # equal character
+        \s*         # whitespace
+        (\S+)       # name
+        """,
+        re.VERBOSE,
+    )
 
-def read_kimspec_template_and_render(
-    template_file_directory_path, template_variables, kimspec_name
-):
-    kimspec_file_temp = kimspec_name + ".genie"
-    file_newconf = os.path.join(template_file_directory_path, kimspec_file_temp)
-    kimspec_template = template_environment.get_template(file_newconf)
-    kimspec = kimspec_template.render(**template_variables)
-    return kimspec
+    def __init__(
+        self,
+        template_file_directory_path,
+        template_variables,
+        destination,
+        overwrite=False,
+        dry_run=False,
+        filename_prefix=None,
+        filename_extension=None,
+        logger=None,
+    ):
+        self.template_file_directory_path = template_file_directory_path
+        self.template_variables = template_variables
+        self.destination = destination
+        self.overwrite = overwrite
+        self.dry_run = dry_run
+        self.filename_prefix = filename_prefix
+        self.filename_extension = filename_extension
+        self.logger = logger
 
-
-def determine_final_file_name(template_file_name, contents, template_variables):
-    """Determine the final name for a rendered file.  If a special file name
-    directive of the form
-      {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
-    is found anywhere in the file, its rendered result will be used as the
-    final file name.  Otherwise, the final file name will be the same as the
-    template file name.
-
-    Parameters
-    ----------
-    template_file_name : str
-        The name of the file in the template file directory
-    contents : str
-        The contents of the template file
-
-    Returns
-    -------
-    str
-        The final name to use for the rendered file.
-    """
-    filename_search = FILENAME_REGEX.search(contents)
-    if filename_search:
-        filename_template_search_result = FILENAME_REGEX.search(contents).group(1)
-        return jinja2.Template(filename_template_search_result).render(
-            **template_variables
+        self.template_environment = jinja2.Environment(
+            loader=jinja2.FileSystemLoader("/")
         )
-    else:
-        return template_file_name
+        self.template_environment.globals.update(
+            {"stripversion": kimcodes.strip_version}
+        )
 
+    def read_kimspec_template_and_render(self):
+        kimspec_file_temp = KIMSPEC_FILE + ".genie"
+        file_newconf = os.path.join(
+            self.template_file_directory_path, kimspec_file_temp
+        )
+        kimspec_template = self.template_environment.get_template(file_newconf)
+        kimspec = kimspec_template.render(**self.template_variables)
+        return kimspec
 
-def move_rendered_item_to_final_destination(
-    tmp_item_dir, item_destination_path, overwrite
-):
-    # Now move the finished item directory to its final home
-    if os.path.isdir(item_destination_path):
-        logger.info("Moving to %s", item_destination_path)
-        if overwrite:
-            shutil.rmtree(item_destination_path)
-            shutil.move(tmp_item_dir, item_destination_path)
+    def determine_final_file_name(self, template_file_name, contents):
+        """Determine the final name for a rendered file.  If a special file name
+        directive of the form
+        {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
+        is found anywhere in the file, its rendered result will be used as the
+        final file name.  Otherwise, the final file name will be the same as the
+        template file name.
+
+        Parameters
+        ----------
+        template_file_name : str
+            The name of the file in the template file directory
+        contents : str
+            The contents of the template file
+
+        Returns
+        -------
+        str
+            The final name to use for the rendered file.
+        """
+        filename_search = self.FILENAME_REGEX.search(contents)
+        if filename_search:
+            filename_template_search_result = self.FILENAME_REGEX.search(
+                contents
+            ).group(1)
+            return jinja2.Template(filename_template_search_result).render(
+                **self.template_variables
+            )
         else:
-            raise OSError(
-                "Directory {} already exists! "
-                "Aborting...".format(item_destination_path)
-            )
-    else:
-        shutil.move(tmp_item_dir, item_destination_path)
+            return template_file_name
 
+    def move_rendered_item_to_final_destination(
+        self, tmp_item_dir, item_destination_path, overwrite
+    ):
+        # Now move the finished item directory to its final home
+        if os.path.isdir(item_destination_path):
+            self.logger.info("Moving to %s", item_destination_path)
+            if overwrite:
+                shutil.rmtree(item_destination_path)
+                shutil.move(tmp_item_dir, item_destination_path)
+            else:
+                raise OSError(
+                    "Directory {} already exists! "
+                    "Aborting...".format(item_destination_path)
+                )
+        else:
+            shutil.move(tmp_item_dir, item_destination_path)
 
-def generate_item(
-    mode,
-    template_file_directory_path,
-    template_variables,
-    destination,
-    overwrite=False,
-    dry_run=False,
-    filename_prefix=None,
-    filename_extension=None,
-    logger=None,
-):
-    """Create an item from a template file directory and a template variable
-    namespace"""
+    def generate_item(self):
+        """Create an item from a template file directory and a template variable
+        namespace"""
 
-    def query_stub(x):
-        """Render everything inside the argument to the query function, then
-        return the output inside of {{ query() }} so the actual query call can
-        be made"""
-        tmp_env = jinja2.Environment(loader=jinja2.BaseLoader).from_string(str(x))
-        tmp_env.globals.update({"stripversion": kimcodes.strip_version})
-        rendered = tmp_env.render(**template_variables)
-        return f"{{{{ query({rendered}) }}}}"
+        def query_stub(x):
+            """Render everything inside the argument to the query function, then
+            return the output inside of {{ query() }} so the actual query call can
+            be made"""
+            tmp_env = jinja2.Environment(loader=jinja2.BaseLoader).from_string(str(x))
+            tmp_env.globals.update({"stripversion": kimcodes.strip_version})
+            rendered = tmp_env.render(**self.template_variables)
+            return f"{{{{ query({rendered}) }}}}"
 
-    if logger is None:
-        logger = logging.getLogger("kimgenie")
-        nullhdlr = logging.NullHandler()
-        logger.addHandler(nullhdlr)
+        if self.logger is None:
+            # If no logger was passed, create one
+            logger = logging.getLogger("kimgenie")
+            nullhdlr = logging.NullHandler()
+            logger.addHandler(nullhdlr)
+        else:
+            logger = self.logger
 
-    try:
-        with tempfile.TemporaryDirectory() as tempdir:
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
 
-            # First parse the kimspec file
-            kimspec = read_kimspec_template_and_render(
-                template_file_directory_path, template_variables, KIMSPEC_FILE
-            )
+                # First parse the kimspec file
+                kimspec = self.read_kimspec_template_and_render()
 
-            with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
-                f.write(kimspec)
+                with open(
+                    os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8"
+                ) as f:
+                    f.write(kimspec)
 
-            # Extend template_variables with everything defined in kimspec
-            kimspeckeys = kim_edn.loads(kimspec)
-            template_variables.update({"kimspec": kimspeckeys})
-            template_variables.update({"query": query_stub})
+                # Extend template_variables with everything defined in kimspec
+                kimspeckeys = kim_edn.loads(kimspec)
+                self.template_variables.update({"kimspec": kimspeckeys})
+                self.template_variables.update({"query": query_stub})
 
-            # Get item name from kimspec
-            if mode == "tests":
-                item_name_kimspec_key = "extended-id"
+                item_name = self.template_variables["kimspec"][
+                    self.item_name_kimspec_key
+                ]
 
-            elif mode == "ref-data":
-                item_name_kimspec_key = "short-id"
+                # Copy template file directory to temporary directory
+                tmp_item_dir = os.path.join(tempdir, item_name)
+                shutil.copytree(self.template_file_directory_path, tmp_item_dir)
 
-            item_name = template_variables["kimspec"][item_name_kimspec_key]
+                logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
+                logger.debug("Variable_dict: %s", self.template_variables)
 
-            # Copy template file directory to temporary directory
-            tmp_item_dir = os.path.join(tempdir, item_name)
-            shutil.copytree(template_file_directory_path, tmp_item_dir)
+                for (basepath, _, files) in os.walk(tmp_item_dir):
+                    for fl in files:
+                        logger.debug("processing %s", fl)
+                        filepath = os.path.join(basepath, fl)
+                        with open(filepath, encoding="utf-8") as f:
+                            contents = f.read()
+                        # copy original mode so we can chmod at end
+                        original_mode = os.stat(filepath).st_mode
+                        template_file_name = fl
 
-            logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
-            logger.debug("Variable_dict: %s", template_variables)
+                        if self.filename_prefix:
+                            if not template_file_name.startswith(self.filename_prefix):
+                                os.remove(filepath)
+                                continue
+                            else:
+                                template_file_name = template_file_name[
+                                    len(self.filename_prefix) :
+                                ]
+                        if self.filename_extension:
+                            if not template_file_name.endswith(self.filename_extension):
+                                os.remove(filepath)
+                                continue
+                            else:
+                                template_file_name = template_file_name[
+                                    : -len(self.filename_extension) - 1
+                                ]
 
-            for (basepath, _, files) in os.walk(tmp_item_dir):
-                for fl in files:
-                    logger.debug("processing %s", fl)
-                    filepath = os.path.join(basepath, fl)
-                    with open(filepath, encoding="utf-8") as f:
-                        contents = f.read()
-                    # copy original mode so we can chmod at end
-                    original_mode = os.stat(filepath).st_mode
-                    template_file_name = fl
+                        final_file_name = self.determine_final_file_name(
+                            template_file_name, contents
+                        )
 
-                    if filename_prefix:
-                        if not template_file_name.startswith(filename_prefix):
-                            os.remove(filepath)
-                            continue
-                        else:
-                            template_file_name = template_file_name[
-                                len(filename_prefix) :
-                            ]
-                    if filename_extension:
-                        if not template_file_name.endswith(filename_extension):
-                            os.remove(filepath)
-                            continue
-                        else:
-                            template_file_name = template_file_name[
-                                : -len(filename_extension) - 1
-                            ]
+                        logger.debug("new file name: %s", final_file_name)
 
-                    final_file_name = determine_final_file_name(
-                        template_file_name, contents, template_variables
+                        # Template everything completely other than query calls, for which we only template
+                        # the arguments for now
+                        template_intermediate = self.template_environment.get_template(
+                            filepath
+                        )
+                        new_contents = template_intermediate.render(
+                            **self.template_variables
+                        )
+
+                        # Now actually perform any queries that might be present and
+                        # write the final rendered template to file
+                        template_final = jinja2.Environment(
+                            loader=jinja2.BaseLoader
+                        ).from_string(str(new_contents))
+                        new_contents = template_final.render({"query": kimquery.query})
+
+                        newfilepath = os.path.join(basepath, final_file_name)
+                        os.remove(filepath)
+
+                        with open(newfilepath, "w", encoding="utf-8") as g:
+                            g.write(new_contents)
+                        # Set permissions to match the corresponding template file
+                        os.chmod(newfilepath, original_mode)
+
+                self.item_destination_path = os.path.join(destination, item_name)
+
+                if not self.dry_run:
+                    self.move_rendered_item_to_final_destination(
+                        tmp_item_dir,
+                        self.item_destination_path,
+                        overwrite=self.overwrite,
                     )
 
-                    logger.debug("new file name: %s", final_file_name)
+        except KeyboardInterrupt:
+            sys.exit(1)
 
-                    # Template everything completely other than query calls, for which we only template
-                    # the arguments for now
-                    template_intermediate = template_environment.get_template(filepath)
-                    new_contents = template_intermediate.render(**template_variables)
+    @property
+    @abstractmethod
+    def item_name_kimspec_key(self):
+        pass
 
-                    # Now actually perform any queries that might be present and
-                    # write the final rendered template to file
-                    template_final = jinja2.Environment(
-                        loader=jinja2.BaseLoader
-                    ).from_string(str(new_contents))
-                    new_contents = template_final.render({"query": kimquery.query})
 
-                    newfilepath = os.path.join(basepath, final_file_name)
-                    os.remove(filepath)
+class TestGenerator(ItemGenerator):
+    @property
+    def item_name_kimspec_key(self):
+        return "extended-id"
 
-                    with open(newfilepath, "w", encoding="utf-8") as g:
-                        g.write(new_contents)
-                    # Set permissions to match the corresponding template file
-                    os.chmod(newfilepath, original_mode)
 
-            item_destination_path = os.path.join(destination, item_name)
-
-            if not dry_run:
-                move_rendered_item_to_final_destination(
-                    tmp_item_dir, item_destination_path, overwrite=overwrite
-                )
-
-            return item_destination_path
-
-    except KeyboardInterrupt:
-        sys.exit(1)
+class RefDataGenerator(ItemGenerator):
+    @property
+    def item_name_kimspec_key(self):
+        return "short-id"
 
 
 def setup_logging(logfile, verbose):
@@ -649,9 +683,6 @@ if __name__ == "__main__":
         global_template_vars, template_file_directory_path, global_variables_file
     )
 
-    template_environment = jinja2.Environment(loader=jinja2.FileSystemLoader("/"))
-    template_environment.globals.update({"stripversion": kimcodes.strip_version})
-
     # Set up logger if necessary
     logger = setup_logging(log_file, verbose)
 
@@ -663,6 +694,8 @@ if __name__ == "__main__":
     if add_random_kimnums:
         add_random_kimnum(root_dir, template_file_directory_path, generator_file)
 
+    item_generator_classes = {"tests": TestGenerator, "ref-data": RefDataGenerator}
+
     # Generate items one-by-one
     with open(
         os.path.join(template_file_directory_path, "..", generator_file),
@@ -671,15 +704,20 @@ if __name__ == "__main__":
         for line in f:
             template_variables = global_template_vars.copy()
             template_variables.update(json.loads(line))
-            new_item_path = generate_item(
-                action,
+
+            item_generator_cls = item_generator_classes[action]
+
+            item_generator = item_generator_cls(
                 template_file_directory_path,
-                template_variables=template_variables,
-                destination=destination,
-                overwrite=overwrite,
-                dry_run=dry_run,
-                filename_prefix=filename_prefix,
-                filename_extension=filename_extension,
-                logger=logger,
+                template_variables,
+                destination,
+                overwrite,
+                dry_run,
+                filename_prefix,
+                filename_extension,
+                logger,
             )
-            print(new_item_path)
+
+            item_generator.generate_item()
+
+            print(item_generator.item_destination_path)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -449,7 +449,7 @@ def create_shared_arguments():
     shared = argparse.ArgumentParser(add_help=False)
 
     shared.add_argument(
-        "--global-variables",
+        "--global-variables-file",
         type=str,
         help="Additional JSON-formatted dictionary of global variables, as file or string",
     )
@@ -678,7 +678,7 @@ if __name__ == "__main__":
     generator_file = args["generator_file"]
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
-    global_variables_file = args["global_variables"]
+    global_variables_file = args["global_variables_file"]
     log_file = args["log_file"]
     verbose = args["verbose"]
     version = args["version"]

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -63,6 +63,7 @@ import re
 import random
 import json
 import sys
+import pathlib
 
 import jinja2
 import kim_edn
@@ -150,7 +151,7 @@ class ItemGenerator:
             {"stripversion": kimcodes.strip_version}
         )
 
-    def read_kimspec_template_and_render(self):
+    def _read_kimspec_template_and_render(self):
         kimspec_file_temp = KIMSPEC_FILE + ".genie"
         file_newconf = os.path.join(
             self.template_file_directory_path, kimspec_file_temp
@@ -159,7 +160,7 @@ class ItemGenerator:
         kimspec = kimspec_template.render(**self.template_variables)
         return kimspec
 
-    def determine_final_file_name(self, template_file_name, contents):
+    def _determine_final_file_name(self, template_file_name, contents):
         """Determine the final name for a rendered file.  If a special file name
         directive of the form
         {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
@@ -190,7 +191,7 @@ class ItemGenerator:
         else:
             return template_file_name
 
-    def move_rendered_item_to_final_destination(
+    def _move_rendered_item_to_final_destination(
         self, tmp_item_dir, item_destination_path, overwrite
     ):
         # Now move the finished item directory to its final home
@@ -211,7 +212,7 @@ class ItemGenerator:
         """Create an item from a template file directory and a template variable
         namespace"""
 
-        def query_stub(x):
+        def _query_stub(x):
             """Render everything inside the argument to the query function, then
             return the output inside of {{ query() }} so the actual query call can
             be made"""
@@ -232,7 +233,7 @@ class ItemGenerator:
             with tempfile.TemporaryDirectory() as tempdir:
 
                 # First parse the kimspec file
-                kimspec = self.read_kimspec_template_and_render()
+                kimspec = self._read_kimspec_template_and_render()
 
                 with open(
                     os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8"
@@ -242,10 +243,10 @@ class ItemGenerator:
                 # Extend template_variables with everything defined in kimspec
                 kimspeckeys = kim_edn.loads(kimspec)
                 self.template_variables.update({"kimspec": kimspeckeys})
-                self.template_variables.update({"query": query_stub})
+                self.template_variables.update({"query": _query_stub})
 
                 item_name = self.template_variables["kimspec"][
-                    self.item_name_kimspec_key
+                    self._item_name_kimspec_key
                 ]
 
                 # Copy template file directory to temporary directory
@@ -282,7 +283,7 @@ class ItemGenerator:
                                     : -len(self.filename_extension) - 1
                                 ]
 
-                        final_file_name = self.determine_final_file_name(
+                        final_file_name = self._determine_final_file_name(
                             template_file_name, contents
                         )
 
@@ -315,7 +316,7 @@ class ItemGenerator:
                 self.item_destination_path = os.path.join(destination, item_name)
 
                 if not self.dry_run:
-                    self.move_rendered_item_to_final_destination(
+                    self._move_rendered_item_to_final_destination(
                         tmp_item_dir,
                         self.item_destination_path,
                         overwrite=self.overwrite,
@@ -326,19 +327,19 @@ class ItemGenerator:
 
     @property
     @abstractmethod
-    def item_name_kimspec_key(self):
+    def _item_name_kimspec_key(self):
         pass
 
 
 class TestGenerator(ItemGenerator):
     @property
-    def item_name_kimspec_key(self):
+    def _item_name_kimspec_key(self):
         return "extended-id"
 
 
 class RefDataGenerator(ItemGenerator):
     @property
-    def item_name_kimspec_key(self):
+    def _item_name_kimspec_key(self):
         return "short-id"
 
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -113,6 +113,14 @@ FILENAME_REGEX = re.compile(
 )
 
 
+def read_kimspec_template_and_render(directory, template_variables, kimspec_name):
+    kimspec_file_temp = kimspec_name + ".genie"
+    file_newconf = os.path.join(directory, kimspec_file_temp)
+    kimspec_template = template_environment.get_template(file_newconf)
+    kimspec = kimspec_template.render(**template_variables)
+    return kimspec
+
+
 def generate_item(
     directory,
     template_variables,
@@ -123,7 +131,8 @@ def generate_item(
     filename_extension=None,
     logger=None,
 ):
-    """Make a Test given the input directory"""
+    """Create an item from a template file directory and a template variable
+    namespace"""
 
     def query_stub(x):
         """Render everything inside the argument to the query function, then
@@ -143,11 +152,9 @@ def generate_item(
         with tempfile.TemporaryDirectory() as tempdir:
 
             # First parse the kimspec file
-            KIMSPEC_FILE_TEMP = KIMSPEC_FILE + ".genie"
-
-            file_newconf = os.path.join(directory, KIMSPEC_FILE_TEMP)
-            kimspec_template = template_environment.get_template(file_newconf)
-            kimspec = kimspec_template.render(**template_variables)
+            kimspec = read_kimspec_template_and_render(
+                directory, template_variables, KIMSPEC_FILE
+            )
 
             with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
                 f.write(kimspec)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -191,12 +191,12 @@ def generate_item(
             tmp_item_dir = os.path.join(tempdir, item_name)
             shutil.copytree(template_file_directory_path, tmp_item_dir)
 
-            logger.info("BUILDING: {} @ {}".format(item_name, tmp_item_dir))
-            logger.debug("Variable_dict: {}".format(template_variables))
+            logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
+            logger.debug("Variable_dict: %s", template_variables)
 
             for (basepath, _, files) in os.walk(tmp_item_dir):
                 for fl in files:
-                    logger.debug("processing {}".format(fl))
+                    logger.debug("processing %s", fl)
                     filepath = os.path.join(basepath, fl)
                     with open(filepath, encoding="utf-8") as f:
                         contents = f.read()
@@ -222,7 +222,7 @@ def generate_item(
                             **template_variables
                         )
 
-                    logger.debug("new file name: {}".format(filename))
+                    logger.debug("new file name: %s", filename)
 
                     # Template everything completely other than query calls, for which we only template
                     # the arguments for now
@@ -249,7 +249,7 @@ def generate_item(
             if not dry_run:
                 # Now move the finished item directory to its final home
                 if os.path.isdir(item_dest_name):
-                    logger.info("Moving to {}".format(item_dest_name))
+                    logger.info("Moving to %s", item_dest_name)
                     if overwrite:
                         shutil.rmtree(item_dest_name)
                         shutil.move(tmp_item_dir, item_dest_name)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -64,7 +64,7 @@ import json
 import sys
 
 import jinja2
-import edn_format
+import kim_edn
 
 from excerpts import kimquery, kimcodes
 import excerpts.config as cf
@@ -152,7 +152,7 @@ def maketest(
             f.write(kimspec)
 
         # Extend template_variables with everything defined in kimspec
-        kimspeckeys = edn_format.loads(kimspec, write_ply_tables=False)
+        kimspeckeys = kim_edn.loads(kimspec)
         template_variables.update({"kimspec": kimspeckeys})
         template_variables.update({"query": query_stub})
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -122,6 +122,7 @@ def read_kimspec_template_and_render(directory, template_variables, kimspec_name
 
 
 def generate_item(
+    mode,
     directory,
     template_variables,
     dest=TEDIR,
@@ -164,14 +165,20 @@ def generate_item(
             template_variables.update({"kimspec": kimspeckeys})
             template_variables.update({"query": query_stub})
 
-            # Get Test name from kimspec
-            test_name = template_variables["kimspec"]["extended-id"]
+            # Get item name from kimspec
+            if mode == "tests":
+                item_name_kimspec_key = "extended-id"
+
+            elif mode == "ref-data":
+                item_name_kimspec_key = "short-id"
+
+            item_name = template_variables["kimspec"][item_name_kimspec_key]
 
             # Create temporary directory
-            tmp_test_dir = os.path.join(tempdir, test_name)
+            tmp_test_dir = os.path.join(tempdir, item_name)
             shutil.copytree(directory, tmp_test_dir)
 
-            logger.info("BUILDING: {} @ {}".format(test_name, tmp_test_dir))
+            logger.info("BUILDING: {} @ {}".format(item_name, tmp_test_dir))
             logger.debug("Variable_dict: {}".format(template_variables))
 
             for (basepath, _, files) in os.walk(tmp_test_dir):
@@ -224,7 +231,7 @@ def generate_item(
                     # Set permissions to match the corresponding template file
                     os.chmod(newfilepath, original_mode)
 
-            test_dest_name = os.path.join(dest, test_name)
+            test_dest_name = os.path.join(dest, item_name)
 
             if not dry_run:
                 # Now move the finished Test directory to its final home
@@ -245,7 +252,7 @@ def generate_item(
                 # Clean up
                 shutil.rmtree(tempdir)
 
-                return os.path.join(dest, test_name)
+                return os.path.join(dest, item_name)
 
             # Clean up
             shutil.rmtree(tempdir)
@@ -583,6 +590,7 @@ if __name__ == "__main__":
             template_variables = global_template_vars.copy()
             template_variables.update(json.loads(line))
             newtestpath = generate_item(
+                action,
                 template_file_directory_path,
                 template_variables=template_variables,
                 dest=dest,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -397,6 +397,24 @@ def create_shared_arguments():
     return shared
 
 
+def process_tests_root_dir_and_test_driver_options(root_dir, test_driver):
+
+    if root_dir and test_driver:
+        raise IncompatibleArgumentCombination(
+            "When generating tests, only one of the 'root-dir' or "
+            "'test-driver' options may be given."
+        )
+    elif (not root_dir) and (not test_driver):
+        raise IncompatibleArgumentCombination(
+            "When generating tests, at least one of the 'root-dir' or "
+            "'test-driver' options must be given."
+        )
+    elif (not root_dir) and test_driver:
+        root_dir = os.path.join(TDDIR, test_driver)
+
+    return root_dir, test_driver
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -474,24 +492,14 @@ if __name__ == "__main__":
         sys.exit(1)
 
     elif action == "tests":
-        test_driver = args.get("test_driver")
-        root_dir = args.get("root_dir")
-        if root_dir and test_driver:
-            raise IncompatibleArgumentCombination(
-                "When generating tests, only one of the 'root-dir' or "
-                "'test-driver' options may be given."
-            )
-        elif (not root_dir) and (not test_driver):
-            raise IncompatibleArgumentCombination(
-                "When generating tests, at least one of the 'root-dir' or "
-                "'test-driver' options must be given."
-            )
-        elif (not root_dir) and test_driver:
+        root_dir = args["root_dir"]
+        test_driver = args["test_driver"]
+        process_tests_root_dir_and_test_driver_options(root_dir, test_driver)
+        if test_driver:
             global_template_vars["TEST_DRIVER_NAME"] = test_driver
-            root_dir = os.path.join(TDDIR, test_driver)
 
     elif action == "ref-data":
-        root_dir = args.get("root-dir")
+        root_dir = args["root-dir"]
 
     template_file_directory_path = os.path.join(root_dir, template_files_dir)
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -159,10 +159,11 @@ class ItemGenerator:
 
     def _read_kimspec_template_and_render(self):
         kimspec_file_temp = KIMSPEC_FILE + ".genie"
-        file_newconf = os.path.join(
-            self.template_file_directory_path, kimspec_file_temp
+        file_newconf = (
+            pathlib.Path(self.template_file_directory_path) / kimspec_file_temp
         )
-        kimspec_template = self.template_environment.get_template(file_newconf)
+        file_newconf_abs = str(file_newconf.resolve())
+        kimspec_template = self.template_environment.get_template(file_newconf_abs)
         kimspec = kimspec_template.render(**self.template_variables)
         return kimspec
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -249,6 +249,24 @@ def maketest(
         sys.exit(1)
 
 
+def setup_logging(logfile, verbose):
+    if logfile:
+        if os.path.isfile(logfile):
+            overwrite_log = input(
+                "Log file {} already exists.  Would you like to overwrite "
+                "this file (y/n)? ".format(logfile)
+            )
+            overwrite_log = overwrite_log.lower()
+            if overwrite_log.lower() in ["y", "yes"]:
+                os.remove(logfile)
+                return createLogger(logfile, verbose=verbose)
+            else:
+                print("Aborting Test generation")
+                sys.exit(0)
+        else:
+            return createLogger(logfile, verbose=verbose)
+
+
 def create_shared_arguments():
     # Shared arguments for the subactions themselves
     shared = argparse.ArgumentParser(add_help=False)
@@ -413,7 +431,6 @@ if __name__ == "__main__":
     parse_ref_data.set_defaults(action="ref-data")
 
     args = vars(parser.parse_args())
-    logger = None
 
     global_vars = {}
 
@@ -447,21 +464,7 @@ if __name__ == "__main__":
     template_environment.globals.update({"stripversion": kimcodes.strip_version})
 
     # Set up logger if necessary
-    if args["logfile"]:
-        if os.path.isfile(args["logfile"]):
-            overwrite_log = input(
-                "Log file {} already exists.  Would you like to overwrite "
-                "this file (y/n)? ".format(args["logfile"])
-            )
-            overwrite_log = overwrite_log.lower()
-            if overwrite_log.lower() in ["y", "yes"]:
-                os.remove(args["logfile"])
-                logger = createLogger(args["logfile"], verbose=args["verbose"])
-            else:
-                print("Aborting Test generation")
-                exit()
-        else:
-            logger = createLogger(args["logfile"], verbose=args["verbose"])
+    logger = setup_logging(args["logfile"], args["verbose"])
 
     # Destination directory
     dest = args["destination"]

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -53,7 +53,7 @@ if necessary, e.g.
   kimgenie tests --test-driver mytestdriver__TD_000000000000_000 > list_of_generated_tests.txt
   cat list_of_generated_tests.txt | xargs rm -r
 
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -27,7 +27,8 @@ the Jinja2 python package.  The generation of an item takes place in stages:
           {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
         directive exists anywhere in the file.  If so, this is used to
         determine the name of the corresponding rendered file in the generated
-        item.
+        item. NOTE: Ensure that this directive is not immediately preceded by
+        another curly bracket (resulting in '{{# FILENAME...').
      b. Process the rest of the file as a Jinja template, excluding any calls
         to the 'query' function, which is defined in the global template
         variable namespace

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -5,7 +5,7 @@ kimgenie - A simple templating tool for creating KIM Tests and Reference Data
 This tool is capable of generating Tests or Reference Data.
 
 In both modes of operation, the inputs to the tool consist of two parts: (1) a
-directory containing a set of template files and (2) a separate "generator
+root directory containing a set of template files and (2) a separate "generator
 file" that contains JSON dictionaries on each line, each corresponding to a
 Test or Reference Data item to be generated, that are used to render the
 template files.  The template files should be formatted to be processed with
@@ -31,9 +31,9 @@ the Jinja2 python package.  The generation of an item takes place in stages:
      b. Process the rest of the file as a Jinja template, excluding any calls
         to the 'query' function, which is defined in the global template
         variable namespace
-  8. After all other template variables have been rendered, make any calls to
+  7. After all other template variables have been rendered, make any calls to
      'query' function that are present and render the results
-  9. Create the item directory under the appropriate item type subdirectory of
+  8. Create the item directory under the appropriate item type subdirectory of
     ${HOME}
 
 NOTE: For convenience, if the --add-random-kimnums flag is given, the current
@@ -75,8 +75,10 @@ TEDIR = os.path.join(cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["te"])
 KIMSPEC_FILE = cf.CONFIG_FILE
 TEMPLATEDIR = "test_template"
 
-# The required argument 'test_driver' is required to be a valid KIM ID for a Test Driver
-RE_TESTDRIVER = r"^(?:([_a-zA-Z][_a-zA-Z0-9]*?)__)?(TD)_([0-9]{12})(?:_([0-9]{3}))$"
+
+class IncompatibleArgumentCombination(Exception):
+    """An incompatible combination of options was passed to the tool"""
+
 
 ##############################
 # Define logger
@@ -251,18 +253,17 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="KIM Test generation genie",
+        description="KIM item generation genie",
         epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    parser.add_argument(
-        "test-driver",
-        type=str,
-        help="Extended KIM ID of the Test Driver whose Tests you wish to generate",
-    )
+    sub = parser.add_subparsers()
 
-    parser.add_argument(
+    # Shared arguments for the subactions themselves
+    shared = argparse.ArgumentParser(add_help=False)
+
+    shared.add_argument(
         "--template-dir",
         type=str,
         default=TEMPLATEDIR,
@@ -271,49 +272,42 @@ if __name__ == "__main__":
         ),
     )
 
-    parser.add_argument(
-        "--source",
-        type=str,
-        default=TDDIR,
-        help="Parent directory of Test Driver [default: {}]".format(TDDIR),
-    )
-
-    parser.add_argument(
+    shared.add_argument(
         "--generator-file",
         type=str,
         default="test_generator.json",
         help="Generator file [default: test_generator.json]",
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--global-variables",
         type=str,
         help="Additional JSON-formatted dictionary of global variables, as file or string",
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--dry-run",
         action="store_true",
-        help="Don't actually create the Tests, but rather just show what would be generated",
+        help="Don't actually create the items, but rather just show what would be generated",
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--destination",
         type=str,
         default=TEDIR,
-        help="Destination directory for generated Tests [default: {}]".format(TEDIR),
+        help="Destination directory for generated items [default: {}]".format(TEDIR),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--overwrite",
         action="store_true",
         help=(
-            "Overwrite any existing Test directories which already exist at the locations where "
+            "Overwrite any existing item directories which already exist at the locations where "
             "the Tests being generated are trying to be written to. Use with caution!"
         ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--add-random-kimnums",
         action="store_true",
         help=(
@@ -327,43 +321,121 @@ if __name__ == "__main__":
         ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--filename-prefix",
         type=str,
-        help="File name prefix; only files with the specified prefix are processed.",
+        help=(
+            "File name prefix; only files with the specified prefix are "
+            "included in the rendered item directories."
+        ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--filename-extension",
         type=str,
-        help="File name extension; only files with the specified extension are processed.",
+        help=(
+            "File name extension; only files with the specified extension are "
+            "included in the rendered item directories."
+        ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--version",
         type=int,
         default=0,
-        help="Parameter to pass as 'version' to global dictionary",
+        help=(
+            "Used to define the 'version' variable in the template variable "
+            "namespace.  Although this option is an integer, it will be cast "
+            "to a three-character string, e.g. a value of 1 is mapped to "
+            "string '001'."
+        ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "--logfile",
         type=str,
         help=(
             "Name of file to write logs to. If left unspecified, logs are not written "
-            "(although the list of generated Tests is still printed to the console)."
+            "(although the list of generated items is still printed to the terminal)."
         ),
     )
 
-    parser.add_argument(
+    shared.add_argument(
         "-v",
         "--verbose",
         action="store_true",
         help="Show debugging messages and timestamps in logs",
     )
 
+    # Subactions that can be performed
+    parse_tests = sub.add_parser(
+        name="tests", parents=[shared], help=("Generate Tests")
+    )
+    parse_ref_data = sub.add_parser(
+        name="ref-data", parents=[shared], help=("Generate Reference Data")
+    )
+
+    # Custom options for each subaction
+    parse_tests.add_argument(
+        "--test-driver",
+        type=str,
+        help=(
+            "Extended KIM ID of the Test Driver whose Tests you wish to "
+            "generate.  Either this option or the 'root-dir' option should be "
+            "given.  If this option is specified, the corresponding Test "
+            f"Driver directory must exist under {TDDIR}."
+        ),
+    )
+    parse_tests.add_argument(
+        "--root-dir",
+        type=str,
+        help="The directory that contains the template file directory and "
+        "generator file. Either this option must be supplied or the "
+        "'test-driver' option must be given.",
+    )
+
+    parse_ref_data.add_argument(
+        "root-dir",
+        type=str,
+        help=(
+            "The directory that contains the template file directory and "
+            "generator file.  May be an absolute or relative path."
+        ),
+    )
+
+    parse_tests.set_defaults(action="tests")
+    parse_ref_data.set_defaults(action="ref-data")
+
     args = vars(parser.parse_args())
     logger = None
+
+    global_vars = {}
+
+    action = args.get("action")
+    if not action:
+        # If no action was given, print help text
+        parser.print_help()
+        sys.exit(1)
+
+    elif action == "tests":
+        test_driver = args.get("test_driver")
+        root_dir = args.get("root_dir")
+        if root_dir and test_driver:
+            raise IncompatibleArgumentCombination(
+                "When generating tests, only one of the 'root-dir' or "
+                "'test-driver' options may be given."
+            )
+        elif (not root_dir) and (not test_driver):
+            raise IncompatibleArgumentCombination(
+                "When generating tests, at least one of the 'root-dir' or "
+                "'test-driver' options must be given."
+            )
+        elif (not root_dir) and test_driver:
+            global_vars["TEST_DRIVER_NAME"] = test_driver
+            root_dir = os.path.join(TDDIR, test_driver)
+
+    elif action == "ref-data":
+        root_dir = args.get("root-dir")
 
     template_environment = jinja2.Environment(loader=jinja2.FileSystemLoader("/"))
     template_environment.globals.update({"stripversion": kimcodes.strip_version})
@@ -385,18 +457,6 @@ if __name__ == "__main__":
         else:
             logger = createLogger(args["logfile"], verbose=args["verbose"])
 
-    # Before we do anything, check that the Test Driver supplied is a proper Extended ID
-    if not re.match(RE_TESTDRIVER, args["test_driver"]):
-        print(
-            "ERROR: {} is not a valid KIM ID for a Test Driver. Aborting "
-            "Test generation.\n  See https://openkim.org/about-kim-ids/ "
-            "for information about KIM IDs.".format(args["test_driver"])
-        )
-        exit(1)
-
-    # Source directory
-    source = args["source"]
-
     # Destination directory
     dest = args["destination"]
     overwrite = args["overwrite"]
@@ -406,14 +466,12 @@ if __name__ == "__main__":
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
 
-    # Expand ~ to home directory in source and dest
-    source = re.sub("~", os.path.expanduser("~"), source)
+    # Expand ~ to home directory in dest
     dest = re.sub("~", os.path.expanduser("~"), dest)
 
-    # Find test_template directory
-    td_template_path = os.path.join(source, args["test_driver"], args["template_dir"])
+    # Find template file directory
+    template_file_directory_path = os.path.join(root_dir, args["template_dir"])
 
-    global_vars = {"TEST_DRIVER_NAME": args["test_driver"]}
     global_vars["version"] = "{:03d}".format(args["version"])
 
     # Get global vars
@@ -421,7 +479,9 @@ if __name__ == "__main__":
         global_path = args["global_variables"]
         try:
             with open(
-                os.path.abspath(os.path.join(td_template_path, "..", global_path)),
+                os.path.abspath(
+                    os.path.join(template_file_directory_path, "..", global_path)
+                ),
                 encoding="utf-8",
             ) as f:
                 global_vars = json.loads(f.read())
@@ -434,7 +494,8 @@ if __name__ == "__main__":
         generator_file_dicts = []
         # First, read generator file and ensure there are no 'kimnum' entries
         with open(
-            os.path.join(td_template_path, "..", generator_file), encoding="utf-8"
+            os.path.join(template_file_directory_path, "..", generator_file),
+            encoding="utf-8",
         ) as f:
             for line in f:
                 this_dict = json.loads(line)
@@ -446,29 +507,30 @@ if __name__ == "__main__":
                         "dictionaries in generator file {}. Please remove "
                         "all instances of 'kimnum' if you wish to use "
                         "--add-random-kimnums. Aborting test "
-                        "generation.".format(
-                            os.path.join(source, args["test_driver"], generator_file)
-                        )
+                        "generation.".format(os.path.join(root_dir, generator_file))
                     )
                     sys.exit(1)
 
         # Now loop over the contents of the generator file and add random kimnums to each dict
         with open(
-            os.path.join(td_template_path, "..", generator_file), "w", encoding="utf-8"
+            os.path.join(template_file_directory_path, "..", generator_file),
+            "w",
+            encoding="utf-8",
         ) as f:
             for this_dict in generator_file_dicts:
                 this_dict["kimnum"] = "%012d" % random.randint(0, 1e12 - 1)
                 f.write(json.dumps(this_dict) + "\n")
 
-    # Generate Tests
+    # Generate items
     with open(
-        os.path.join(td_template_path, "..", generator_file), encoding="utf-8"
+        os.path.join(template_file_directory_path, "..", generator_file),
+        encoding="utf-8",
     ) as f:
         for line in f:
             template_variables = global_vars.copy()
             template_variables.update(json.loads(line))
             newtestpath = maketest(
-                td_template_path,
+                template_file_directory_path,
                 template_variables=template_variables,
                 dest=dest,
                 overwrite=overwrite,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -249,17 +249,7 @@ def maketest(
         sys.exit(1)
 
 
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="KIM item generation genie",
-        epilog=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-
-    sub = parser.add_subparsers()
-
+def create_shared_arguments():
     # Shared arguments for the subactions themselves
     shared = argparse.ArgumentParser(add_help=False)
 
@@ -366,6 +356,22 @@ if __name__ == "__main__":
         action="store_true",
         help="Show debugging messages and timestamps in logs",
     )
+
+    return shared
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="KIM item generation genie",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    sub = parser.add_subparsers()
+
+    shared = create_shared_arguments()
 
     # Subactions that can be performed
     parse_tests = sub.add_parser(

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -164,11 +164,29 @@ def determine_final_file_name(template_file_name, contents, template_variables):
         return template_file_name
 
 
+def move_rendered_item_to_final_destination(
+    tmp_item_dir, item_destination_path, overwrite
+):
+    # Now move the finished item directory to its final home
+    if os.path.isdir(item_destination_path):
+        logger.info("Moving to %s", item_destination_path)
+        if overwrite:
+            shutil.rmtree(item_destination_path)
+            shutil.move(tmp_item_dir, item_destination_path)
+        else:
+            raise OSError(
+                "Directory {} already exists! "
+                "Aborting...".format(item_destination_path)
+            )
+    else:
+        shutil.move(tmp_item_dir, item_destination_path)
+
+
 def generate_item(
     mode,
     template_file_directory_path,
     template_variables,
-    dest,
+    destination,
     overwrite=False,
     dry_run=False,
     filename_prefix=None,
@@ -277,27 +295,14 @@ def generate_item(
                     # Set permissions to match the corresponding template file
                     os.chmod(newfilepath, original_mode)
 
-            item_dest_name = os.path.join(dest, item_name)
+            item_destination_path = os.path.join(destination, item_name)
 
             if not dry_run:
-                # Now move the finished item directory to its final home
-                if os.path.isdir(item_dest_name):
-                    logger.info("Moving to %s", item_dest_name)
-                    if overwrite:
-                        shutil.rmtree(item_dest_name)
-                        shutil.move(tmp_item_dir, item_dest_name)
-                    else:
-                        shutil.rmtree(tempdir)
-                        raise OSError(
-                            "Directory {} already exists! "
-                            "Aborting...".format(item_dest_name)
-                        )
-                else:
-                    shutil.move(tmp_item_dir, item_dest_name)
+                move_rendered_item_to_final_destination(
+                    tmp_item_dir, item_destination_path, overwrite=overwrite
+                )
 
-                return os.path.join(dest, item_name)
-
-            return item_dest_name
+            return item_destination_path
 
     except KeyboardInterrupt:
         sys.exit(1)
@@ -603,7 +608,7 @@ if __name__ == "__main__":
     # Pull args passed on command line
     args = vars(parser.parse_args())
 
-    dest = args["destination"]
+    destination = args["destination"]
     overwrite = args["overwrite"]
     dry_run = args["dry_run"]
     add_random_kimnums = args["add_random_kimnums"]
@@ -651,7 +656,7 @@ if __name__ == "__main__":
     logger = setup_logging(log_file, verbose)
 
     # Expand ~ to home directory in dest
-    dest = expand_tilde_to_home_dir(dest)
+    destination = expand_tilde_to_home_dir(destination)
 
     # If user provided add-random-kimnums option, attempt to overwrite their
     # generator file
@@ -670,7 +675,7 @@ if __name__ == "__main__":
                 action,
                 template_file_directory_path,
                 template_variables=template_variables,
-                dest=dest,
+                destination=destination,
                 overwrite=overwrite,
                 dry_run=dry_run,
                 filename_prefix=filename_prefix,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -32,8 +32,12 @@ the Jinja2 python package.  The generation of an item takes place in stages:
      b. Process the rest of the file as a Jinja template, excluding any calls
         to the 'query' function, which is defined in the global template
         variable namespace
-  7. After all other template variables have been rendered, make any calls to
-     'query' function that are present and render the results
+     c. After all other template variables have been rendered, make any calls
+     to 'query' function that are present and render the results
+  7. If the special keyword 'FILES_TO_COPY' was given in the dictionary read
+     from the generator file, copy each file listed into the item directory.
+     Note that the value of 'FILES_TO_COPY' should be a list containing strings
+     corresponding to absolute paths of files.
   8. Create the item directory under the appropriate item type subdirectory of
     ${HOME}
 
@@ -89,9 +93,16 @@ DEFAULT_DESTINATION_REFDATA = os.path.join(
     cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["rd"]
 )
 
+FILES_TO_COPY_KEY = "FILES_TO_COPY"
+
 
 class IncompatibleArgumentCombination(Exception):
     """An incompatible combination of options was passed to the tool"""
+
+
+class InvalidFilesToCopy(Exception):
+    """The list of files to copy given in a line of a generator file was not a
+    list"""
 
 
 ##############################
@@ -214,6 +225,21 @@ class ItemGenerator:
         else:
             shutil.move(self.tmp_item_dir, item_dest)
 
+    def _copy_additional_files_to_item_dir(self):
+        files_to_copy = self.template_variables[FILES_TO_COPY_KEY]
+        # Enforce that a list was passed
+        if not isinstance(files_to_copy, list) or not all(
+            isinstance(fl_name, str) for fl_name in files_to_copy
+        ):
+            raise InvalidFilesToCopy(
+                f"The value of the reserved key '{FILES_TO_COPY_KEY}' must be "
+                "a list of strings corresponding to absolute paths of files "
+                "to copy into the rendered item directory"
+            )
+
+        for abs_file_path in files_to_copy:
+            shutil.copy2(abs_file_path, self.tmp_item_dir)
+
     def generate_item(self):
         """Create an item from a template file directory and a template variable
         namespace"""
@@ -260,6 +286,7 @@ class ItemGenerator:
                         filepath = os.path.join(basepath, fl)
                         with open(filepath, encoding="utf-8") as f:
                             contents = f.read()
+
                         # copy original mode so we can chmod at end
                         original_mode = os.stat(filepath).st_mode
                         template_file_name = fl
@@ -310,6 +337,11 @@ class ItemGenerator:
                             g.write(new_contents)
                         # Set permissions to match the corresponding template file
                         os.chmod(newfilepath, original_mode)
+
+                # Copy any additional files specified that are specified to
+                # this item
+                if FILES_TO_COPY_KEY in self.template_variables:
+                    self._copy_additional_files_to_item_dir()
 
                 self.item_destination_path = os.path.join(
                     self.destination, self.item_name

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -1,42 +1,51 @@
 #! /usr/bin/env python3
 """
-testgenie - A simple templating tool for creating KIM Tests
+kimgenie - A simple templating tool for creating KIM Tests and Reference Data
 
-This utility takes the name of a Test Driver, the path of a directory containing
-the template files that will be created for each Test, and a file containing
-JSON-formatted dictionaries (one per line).  Each JSON dictionary is used to fill
-in the Jinja directives in each of the template files, generating a single Test.
+This tool is capable of generating Tests or Reference Data.
 
-Test generation takes place in steps:
+In both modes of operation, the inputs to the tool consist of two parts: (1) a
+directory containing a set of template files and (2) a separate "generator
+file" that contains JSON dictionaries on each line, each corresponding to a
+Test or Reference Data item to be generated, that are used to render the
+template files.  The template files should be formatted to be processed with
+the Jinja2 python package.  The generation of an item takes place in stages:
 
-  1. Grab the dictionary defined in a given line of the test_generator.json file
-  2. If a global variables file is specified, add the corresponding varibles
-  3. Process the kimspec.edn.genie file as a Jinja template using the full set of variables
-  4. Add all of the variables defined in the processed kimspec.edn to the local dictionary
-  5. Set the folder name from the 'extended-id' attribute in the processed kimspec.edn file
-  6. For each remaining file, check if a
-        {# FILENAME = desired_file_name_with_{{ variables }} #}
-     directive exists to fix the filename
-  7. Remove prefixes or extensions as necessary
-  8. Process the rest of the file as a Jinja template, excluding any calls to the query function
-  9. After all other template variables have been rendered, make any calls to query function
-     that are present and render the results
-  10. Move folders to the Tests subdir of cf.LOCAL_REPOSITORY_PATH
+  1. Grab the dictionary defined in a given line of the generator file
+  2. If a global template variables file is passed as input, add the
+     corresponding variables to the global template variable namespace used
+     during the rendering process
+  3. Render the kimspec.edn.genie file (which is required to exist) in the
+     template file directory
+  4. Add all of the variables defined in the rendered kimspec.edn to the local
+     template variable namspace being used to generate the current item
+  5. Set the directory name for the item being generated to be equal to the
+     'extended-id' attribute (required to exist) in the rendered kimspec.edn
+     file
+  6. For each remaining file in the template file directory:
+     a. Check if a
+          {# FILENAME = desired_file_name_with_{{ variables }} #}
+        directive exists anywhere in the file.  If so, this is used to
+        determine the name of the corresponding rendered file in the generated
+        item.
+     b. Process the rest of the file as a Jinja template, excluding any calls
+        to the 'query' function, which is defined in the global template
+        variable namespace
+  8. After all other template variables have been rendered, make any calls to
+     'query' function that are present and render the results
+  9. Create the item directory under the appropriate item type subdirectory of
+    ${HOME}
 
-For convenience, if the --add-random-kimnums flag is given, the current generator file will
-be overwritten with one for which random KIM IDs have been added to each dictionary under the
-key name 'kimnum'.  The resulting generator file is then used to complete the Test generation
-process.
+NOTE: For convenience, if the --add-random-kimnums flag is given, the current
+generator file will be overwritten with one for which random KIM IDs have been
+added to each dictionary under the template variable name 'kimnum'.  The
+resulting generator file is then used to carry out the item generation process.
 
-Note also that the script expects the path for the generator file and global
-variables files to be one directory up from the test template folder.  By
-default, 'TEST_DRIVER_NAME' will be the same as 'testdriver' and 'version' will be
-0, or whatever is specified with the command line argument
+NOTE: This tool prints the name of each item directory to stdout after it is
+generated.  This is useful to catch in order to remove these directories later
+if necessary, e.g.
 
-This utility outputs a list of all generated Test folders. This is useful to catch
-in order to remove the folders later if necessary. e.g.
-
-  testgenie mytestdriver__TD_000000000000_000 > list_of_generated_tests.txt
+  kimgenie --tests mytestdriver__TD_000000000000_000 > list_of_generated_tests.txt
   cat list_of_generated_tests.txt | xargs rm -r
 
 Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -290,6 +290,38 @@ def expand_tilde_to_home_dir(path_str):
     return re.sub("~", os.path.expanduser("~"), path_str)
 
 
+def add_random_kimnum(root_dir, template_file_directory_path, generator_file):
+    generator_file_dicts = []
+    # First, read generator file and ensure there are no 'kimnum' entries
+    with open(
+        os.path.join(template_file_directory_path, "..", generator_file),
+        encoding="utf-8",
+    ) as generator_fl:
+        for line in generator_fl:
+            this_dict = json.loads(line)
+            generator_file_dicts.append(this_dict)
+            if "kimnum" in this_dict:
+                print(
+                    "Flag --add-random-kimnums was given, but there is "
+                    "a 'kimnum' key present in one or more of the "
+                    "dictionaries in generator file {}. Please remove "
+                    "all instances of 'kimnum' if you wish to use "
+                    "--add-random-kimnums. Aborting test "
+                    "generation.".format(os.path.join(root_dir, generator_file))
+                )
+                sys.exit(1)
+
+    # Now loop over the contents of the generator file and add random kimnums to each dict
+    with open(
+        os.path.join(template_file_directory_path, "..", generator_file),
+        "w",
+        encoding="utf-8",
+    ) as f:
+        for this_dict in generator_file_dicts:
+            this_dict["kimnum"] = "%012d" % random.randint(0, 1e12 - 1)
+            f.write(json.dumps(this_dict) + "\n")
+
+
 def create_shared_arguments():
     # Shared arguments for the subactions themselves
     shared = argparse.ArgumentParser(add_help=False)
@@ -527,35 +559,7 @@ if __name__ == "__main__":
     # If user provided add-random-kimnums option, attempt to overwrite their
     # generator file
     if random_codes:
-        generator_file_dicts = []
-        # First, read generator file and ensure there are no 'kimnum' entries
-        with open(
-            os.path.join(template_file_directory_path, "..", generator_file),
-            encoding="utf-8",
-        ) as f:
-            for line in f:
-                this_dict = json.loads(line)
-                generator_file_dicts.append(this_dict)
-                if "kimnum" in this_dict:
-                    print(
-                        "Flag --add-random-kimnums was given, but there is "
-                        "a 'kimnum' key present in one or more of the "
-                        "dictionaries in generator file {}. Please remove "
-                        "all instances of 'kimnum' if you wish to use "
-                        "--add-random-kimnums. Aborting test "
-                        "generation.".format(os.path.join(root_dir, generator_file))
-                    )
-                    sys.exit(1)
-
-        # Now loop over the contents of the generator file and add random kimnums to each dict
-        with open(
-            os.path.join(template_file_directory_path, "..", generator_file),
-            "w",
-            encoding="utf-8",
-        ) as f:
-            for this_dict in generator_file_dicts:
-                this_dict["kimnum"] = "%012d" % random.randint(0, 1e12 - 1)
-                f.write(json.dumps(this_dict) + "\n")
+        add_random_kimnum(root_dir, template_file_directory_path, generator_file)
 
     # Generate items
     with open(

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -113,9 +113,11 @@ FILENAME_REGEX = re.compile(
 )
 
 
-def read_kimspec_template_and_render(directory, template_variables, kimspec_name):
+def read_kimspec_template_and_render(
+    template_file_directory_path, template_variables, kimspec_name
+):
     kimspec_file_temp = kimspec_name + ".genie"
-    file_newconf = os.path.join(directory, kimspec_file_temp)
+    file_newconf = os.path.join(template_file_directory_path, kimspec_file_temp)
     kimspec_template = template_environment.get_template(file_newconf)
     kimspec = kimspec_template.render(**template_variables)
     return kimspec
@@ -123,7 +125,7 @@ def read_kimspec_template_and_render(directory, template_variables, kimspec_name
 
 def generate_item(
     mode,
-    directory,
+    template_file_directory_path,
     template_variables,
     dest=TEDIR,
     overwrite=False,
@@ -154,7 +156,7 @@ def generate_item(
 
             # First parse the kimspec file
             kimspec = read_kimspec_template_and_render(
-                directory, template_variables, KIMSPEC_FILE
+                template_file_directory_path, template_variables, KIMSPEC_FILE
             )
 
             with open(os.path.join(tempdir, KIMSPEC_FILE), "w", encoding="utf-8") as f:
@@ -176,7 +178,7 @@ def generate_item(
 
             # Create temporary directory
             tmp_test_dir = os.path.join(tempdir, item_name)
-            shutil.copytree(directory, tmp_test_dir)
+            shutil.copytree(template_file_directory_path, tmp_test_dir)
 
             logger.info("BUILDING: {} @ {}".format(item_name, tmp_test_dir))
             logger.debug("Variable_dict: {}".format(template_variables))
@@ -234,7 +236,7 @@ def generate_item(
             test_dest_name = os.path.join(dest, item_name)
 
             if not dry_run:
-                # Now move the finished Test directory to its final home
+                # Now move the finished item directory to its final home
                 if os.path.isdir(test_dest_name):
                     logger.info("Moving to {}".format(test_dest_name))
                     if overwrite:

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -144,6 +144,12 @@ class ItemGenerator:
         self.filename_extension = filename_extension
         self.logger = logger
 
+        if self.logger is None:
+            # If no logger was passed, create one
+            self.logger = logging.getLogger("kimgenie")
+            nullhdlr = logging.NullHandler()
+            self.logger.addHandler(nullhdlr)
+
         self.template_environment = jinja2.Environment(
             loader=jinja2.FileSystemLoader("/")
         )
@@ -221,14 +227,6 @@ class ItemGenerator:
             rendered = tmp_env.render(**self.template_variables)
             return f"{{{{ query({rendered}) }}}}"
 
-        if self.logger is None:
-            # If no logger was passed, create one
-            logger = logging.getLogger("kimgenie")
-            nullhdlr = logging.NullHandler()
-            logger.addHandler(nullhdlr)
-        else:
-            logger = self.logger
-
         try:
             with tempfile.TemporaryDirectory() as tempdir:
 
@@ -253,12 +251,12 @@ class ItemGenerator:
                 tmp_item_dir = os.path.join(tempdir, item_name)
                 shutil.copytree(self.template_file_directory_path, tmp_item_dir)
 
-                logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
-                logger.debug("Variable_dict: %s", self.template_variables)
+                self.logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
+                self.logger.debug("Variable_dict: %s", self.template_variables)
 
                 for (basepath, _, files) in os.walk(tmp_item_dir):
                     for fl in files:
-                        logger.debug("processing %s", fl)
+                        self.logger.debug("processing %s", fl)
                         filepath = os.path.join(basepath, fl)
                         with open(filepath, encoding="utf-8") as f:
                             contents = f.read()
@@ -287,7 +285,7 @@ class ItemGenerator:
                             template_file_name, contents
                         )
 
-                        logger.debug("new file name: %s", final_file_name)
+                        self.logger.debug("new file name: %s", final_file_name)
 
                         # Template everything completely other than query calls, for which we only template
                         # the arguments for now

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -200,21 +200,22 @@ class ItemGenerator:
             return template_file_name
 
     def _move_rendered_item_to_final_destination(
-        self, tmp_item_dir, item_destination_path, overwrite
+        self
     ):
         # Now move the finished item directory to its final home
-        if os.path.isdir(item_destination_path):
-            self.logger.info("Moving to %s", item_destination_path)
-            if overwrite:
-                shutil.rmtree(item_destination_path)
-                shutil.move(tmp_item_dir, item_destination_path)
+        item_dest = self.item_destination_path
+        if os.path.isdir(item_dest):
+            self.logger.info("Moving to %s", item_dest)
+            if self.overwrite:
+                shutil.rmtree(item_dest)
+                shutil.move(self.tmp_item_dir, item_dest)
             else:
                 raise OSError(
                     "Directory {} already exists! "
-                    "Aborting...".format(item_destination_path)
+                    "Aborting...".format(item_dest)
                 )
         else:
-            shutil.move(tmp_item_dir, item_destination_path)
+            shutil.move(self.tmp_item_dir, item_dest)
 
     def generate_item(self):
         """Create an item from a template file directory and a template variable
@@ -250,13 +251,13 @@ class ItemGenerator:
                 ]
 
                 # Copy template file directory to temporary directory
-                tmp_item_dir = os.path.join(tempdir, item_name)
-                shutil.copytree(self.template_file_directory_path, tmp_item_dir)
+                self.tmp_item_dir = os.path.join(tempdir, item_name)
+                shutil.copytree(self.template_file_directory_path, self.tmp_item_dir)
 
-                self.logger.info("BUILDING: %s @ %s", item_name, tmp_item_dir)
+                self.logger.info("BUILDING: %s @ %s", item_name, self.tmp_item_dir)
                 self.logger.debug("Variable_dict: %s", self.template_variables)
 
-                for (basepath, _, files) in os.walk(tmp_item_dir):
+                for (basepath, _, files) in os.walk(self.tmp_item_dir):
                     for fl in files:
                         self.logger.debug("processing %s", fl)
                         filepath = os.path.join(basepath, fl)
@@ -317,9 +318,6 @@ class ItemGenerator:
 
                 if not self.dry_run:
                     self._move_rendered_item_to_final_destination(
-                        tmp_item_dir,
-                        self.item_destination_path,
-                        overwrite=self.overwrite,
                     )
 
         except KeyboardInterrupt:

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -267,6 +267,25 @@ def setup_logging(logfile, verbose):
             return createLogger(logfile, verbose=verbose)
 
 
+def update_global_template_vars(
+    global_vars, template_file_directory_path, global_variables_file
+):
+    """Update global variables dict from file"""
+    if global_variables_file:
+        try:
+            with open(
+                os.path.abspath(
+                    os.path.join(
+                        template_file_directory_path, "..", global_variables_file
+                    )
+                ),
+                encoding="utf-8",
+            ) as global_vars_fl:
+                global_vars.update(json.loads(global_vars_fl.read()))
+        except IOError:
+            global_vars.update(json.loads(global_variables_file))
+
+
 def create_shared_arguments():
     # Shared arguments for the subactions themselves
     shared = argparse.ArgumentParser(add_help=False)
@@ -440,6 +459,7 @@ if __name__ == "__main__":
     generator_file = args["generator_file"]
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
+    global_variables_file = args["global_variables"]
 
     global_vars = {}
 
@@ -469,6 +489,16 @@ if __name__ == "__main__":
     elif action == "ref-data":
         root_dir = args.get("root-dir")
 
+    template_file_directory_path = os.path.join(root_dir, args["template_dir"])
+
+    global_vars["version"] = "{:03d}".format(args["version"])
+
+    # If the user specified a global variables file, update the global
+    # variables defined thus far
+    update_global_template_vars(
+        global_vars, template_file_directory_path, global_variables_file
+    )
+
     template_environment = jinja2.Environment(loader=jinja2.FileSystemLoader("/"))
     template_environment.globals.update({"stripversion": kimcodes.strip_version})
 
@@ -477,25 +507,6 @@ if __name__ == "__main__":
 
     # Expand ~ to home directory in dest
     dest = re.sub("~", os.path.expanduser("~"), dest)
-
-    # Find template file directory
-    template_file_directory_path = os.path.join(root_dir, args["template_dir"])
-
-    global_vars["version"] = "{:03d}".format(args["version"])
-
-    # Get global vars
-    if args["global_variables"]:
-        global_path = args["global_variables"]
-        try:
-            with open(
-                os.path.abspath(
-                    os.path.join(template_file_directory_path, "..", global_path)
-                ),
-                encoding="utf-8",
-            ) as f:
-                global_vars = json.loads(f.read())
-        except Exception:
-            global_vars = json.loads(global_path)
 
     # If user provided add-random-kimnums option, attempt to overwrite their
     # generator file

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -268,7 +268,7 @@ def setup_logging(logfile, verbose):
 
 
 def update_global_template_vars(
-    global_vars, template_file_directory_path, global_variables_file
+    global_template_vars, template_file_directory_path, global_variables_file
 ):
     """Update global variables dict from file"""
     if global_variables_file:
@@ -280,10 +280,10 @@ def update_global_template_vars(
                     )
                 ),
                 encoding="utf-8",
-            ) as global_vars_fl:
-                global_vars.update(json.loads(global_vars_fl.read()))
+            ) as global_template_vars_fl:
+                global_template_vars.update(json.loads(global_template_vars_fl.read()))
         except IOError:
-            global_vars.update(json.loads(global_variables_file))
+            global_template_vars.update(json.loads(global_variables_file))
 
 
 def create_shared_arguments():
@@ -461,7 +461,7 @@ if __name__ == "__main__":
     filename_extension = args["filename_extension"]
     global_variables_file = args["global_variables"]
 
-    global_vars = {}
+    global_template_vars = {}
 
     action = args.get("action")
     if not action:
@@ -483,7 +483,7 @@ if __name__ == "__main__":
                 "'test-driver' options must be given."
             )
         elif (not root_dir) and test_driver:
-            global_vars["TEST_DRIVER_NAME"] = test_driver
+            global_template_vars["TEST_DRIVER_NAME"] = test_driver
             root_dir = os.path.join(TDDIR, test_driver)
 
     elif action == "ref-data":
@@ -491,12 +491,12 @@ if __name__ == "__main__":
 
     template_file_directory_path = os.path.join(root_dir, args["template_dir"])
 
-    global_vars["version"] = "{:03d}".format(args["version"])
+    global_template_vars["version"] = "{:03d}".format(args["version"])
 
     # If the user specified a global variables file, update the global
     # variables defined thus far
     update_global_template_vars(
-        global_vars, template_file_directory_path, global_variables_file
+        global_template_vars, template_file_directory_path, global_variables_file
     )
 
     template_environment = jinja2.Environment(loader=jinja2.FileSystemLoader("/"))
@@ -547,7 +547,7 @@ if __name__ == "__main__":
         encoding="utf-8",
     ) as f:
         for line in f:
-            template_variables = global_vars.copy()
+            template_variables = global_template_vars.copy()
             template_variables.update(json.loads(line))
             newtestpath = maketest(
                 template_file_directory_path,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -24,7 +24,7 @@ the Jinja2 python package.  The generation of an item takes place in stages:
      file
   6. For each remaining file in the template file directory:
      a. Check if a
-          {# FILENAME = desired_file_name_with_{{ variables }} #}
+          {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
         directive exists anywhere in the file.  If so, this is used to
         determine the name of the corresponding rendered file in the generated
         item.
@@ -134,6 +134,36 @@ def read_kimspec_template_and_render(
     return kimspec
 
 
+def determine_final_file_name(template_file_name, contents, template_variables):
+    """Determine the final name for a rendered file.  If a special file name
+    directive of the form
+      {# FILENAME = desired_file_name_with_{{ template namespace variables }} #}
+    is found anywhere in the file, its rendered result will be used as the
+    final file name.  Otherwise, the final file name will be the same as the
+    template file name.
+
+    Parameters
+    ----------
+    template_file_name : str
+        The name of the file in the template file directory
+    contents : str
+        The contents of the template file
+
+    Returns
+    -------
+    str
+        The final name to use for the rendered file.
+    """
+    filename_search = FILENAME_REGEX.search(contents)
+    if filename_search:
+        filename_template_search_result = FILENAME_REGEX.search(contents).group(1)
+        return jinja2.Template(filename_template_search_result).render(
+            **template_variables
+        )
+    else:
+        return template_file_name
+
+
 def generate_item(
     mode,
     template_file_directory_path,
@@ -187,7 +217,7 @@ def generate_item(
 
             item_name = template_variables["kimspec"][item_name_kimspec_key]
 
-            # Create temporary directory
+            # Copy template file directory to temporary directory
             tmp_item_dir = os.path.join(tempdir, item_name)
             shutil.copytree(template_file_directory_path, tmp_item_dir)
 
@@ -202,27 +232,30 @@ def generate_item(
                         contents = f.read()
                     # copy original mode so we can chmod at end
                     original_mode = os.stat(filepath).st_mode
-                    filename = fl
-                    if filename_prefix:
-                        if not filename.startswith(filename_prefix):
-                            os.remove(filepath)
-                            continue
-                        else:
-                            filename = filename[len(filename_prefix) :]
-                    if filename_extension:
-                        if not filename.endswith(filename_extension):
-                            os.remove(filepath)
-                            continue
-                        else:
-                            filename = filename[: -len(filename_extension) - 1]
-                    filename_search = FILENAME_REGEX.search(contents)
-                    if filename_search:
-                        filename_template = FILENAME_REGEX.search(contents).group(1)
-                        filename = jinja2.Template(filename_template).render(
-                            **template_variables
-                        )
+                    template_file_name = fl
 
-                    logger.debug("new file name: %s", filename)
+                    if filename_prefix:
+                        if not template_file_name.startswith(filename_prefix):
+                            os.remove(filepath)
+                            continue
+                        else:
+                            template_file_name = template_file_name[
+                                len(filename_prefix) :
+                            ]
+                    if filename_extension:
+                        if not template_file_name.endswith(filename_extension):
+                            os.remove(filepath)
+                            continue
+                        else:
+                            template_file_name = template_file_name[
+                                : -len(filename_extension) - 1
+                            ]
+
+                    final_file_name = determine_final_file_name(
+                        template_file_name, contents, template_variables
+                    )
+
+                    logger.debug("new file name: %s", final_file_name)
 
                     # Template everything completely other than query calls, for which we only template
                     # the arguments for now
@@ -236,7 +269,7 @@ def generate_item(
                     ).from_string(str(new_contents))
                     new_contents = template_final.render({"query": kimquery.query})
 
-                    newfilepath = os.path.join(basepath, filename)
+                    newfilepath = os.path.join(basepath, final_file_name)
                     os.remove(filepath)
 
                     with open(newfilepath, "w", encoding="utf-8") as g:

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -251,13 +251,8 @@ def generate_item(
                 else:
                     shutil.move(tmp_test_dir, test_dest_name)
 
-                # Clean up
-                shutil.rmtree(tempdir)
-
                 return os.path.join(dest, item_name)
 
-            # Clean up
-            shutil.rmtree(tempdir)
             return test_dest_name
 
     except KeyboardInterrupt:

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -465,15 +465,18 @@ def create_shared_arguments():
     shared.add_argument(
         "--dry-run",
         action="store_true",
-        help="Don't actually create the items, but rather just show what would be generated",
+        help=(
+            "Don't actually create the items, but rather just show what would "
+            "be generated."
+        ),
     )
 
     shared.add_argument(
         "--filename-extension",
         type=str,
         help=(
-            "File name extension; only files with the specified extension are "
-            "included in the rendered item directories."
+            "Only files with the specified extension are included in the "
+            "rendered item directories."
         ),
     )
 
@@ -481,8 +484,8 @@ def create_shared_arguments():
         "--filename-prefix",
         type=str,
         help=(
-            "File name prefix; only files with the specified prefix are "
-            "included in the rendered item directories."
+            "Only files with the specified prefix are included in the "
+            "rendered item directories."
         ),
     )
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -45,7 +45,7 @@ NOTE: This tool prints the name of each item directory to stdout after it is
 generated.  This is useful to catch in order to remove these directories later
 if necessary, e.g.
 
-  kimgenie --tests mytestdriver__TD_000000000000_000 > list_of_generated_tests.txt
+  kimgenie tests --test-driver mytestdriver__TD_000000000000_000 > list_of_generated_tests.txt
   cat list_of_generated_tests.txt | xargs rm -r
 
 Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -460,6 +460,10 @@ if __name__ == "__main__":
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
     global_variables_file = args["global_variables"]
+    logfile = args["logfile"]
+    verbose = args["verbose"]
+    version = args["version"]
+    template_files_dir = args["template_dir"]
 
     global_template_vars = {}
 
@@ -489,9 +493,9 @@ if __name__ == "__main__":
     elif action == "ref-data":
         root_dir = args.get("root-dir")
 
-    template_file_directory_path = os.path.join(root_dir, args["template_dir"])
+    template_file_directory_path = os.path.join(root_dir, template_files_dir)
 
-    global_template_vars["version"] = "{:03d}".format(args["version"])
+    global_template_vars["version"] = "{:03d}".format(version)
 
     # If the user specified a global variables file, update the global
     # variables defined thus far
@@ -503,7 +507,7 @@ if __name__ == "__main__":
     template_environment.globals.update({"stripversion": kimcodes.strip_version})
 
     # Set up logger if necessary
-    logger = setup_logging(args["logfile"], args["verbose"])
+    logger = setup_logging(logfile, verbose)
 
     # Expand ~ to home directory in dest
     dest = re.sub("~", os.path.expanduser("~"), dest)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -103,7 +103,7 @@ def createLogger(logfile, verbose):
 ################################
 FILENAME_REGEX = re.compile(
     r"""
-    FILENAME    #magic word
+    FILENAME    # magic word
     \s*         # whitespace
     =           # equal character
     \s*         # whitespace
@@ -113,7 +113,7 @@ FILENAME_REGEX = re.compile(
 )
 
 
-def maketest(
+def generate_item(
     directory,
     template_variables,
     dest=TEDIR,
@@ -532,7 +532,7 @@ if __name__ == "__main__":
     if not action:
         # If no action was given, print help text
         parser.print_help()
-        sys.exit(1)
+        sys.exit(0)
 
     elif action == "tests":
         root_dir = args["root_dir"]
@@ -568,7 +568,7 @@ if __name__ == "__main__":
     if add_random_kimnums:
         add_random_kimnum(root_dir, template_file_directory_path, generator_file)
 
-    # Generate items
+    # Generate items one-by-one
     with open(
         os.path.join(template_file_directory_path, "..", generator_file),
         encoding="utf-8",
@@ -576,7 +576,7 @@ if __name__ == "__main__":
         for line in f:
             template_variables = global_template_vars.copy()
             template_variables.update(json.loads(line))
-            newtestpath = maketest(
+            newtestpath = generate_item(
                 template_file_directory_path,
                 template_variables=template_variables,
                 dest=dest,

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -286,6 +286,10 @@ def update_global_template_vars(
             global_template_vars.update(json.loads(global_variables_file))
 
 
+def expand_tilde_to_home_dir(path_str):
+    return re.sub("~", os.path.expanduser("~"), path_str)
+
+
 def create_shared_arguments():
     # Shared arguments for the subactions themselves
     shared = argparse.ArgumentParser(add_help=False)
@@ -518,7 +522,7 @@ if __name__ == "__main__":
     logger = setup_logging(log_file, verbose)
 
     # Expand ~ to home directory in dest
-    dest = re.sub("~", os.path.expanduser("~"), dest)
+    dest = expand_tilde_to_home_dir(dest)
 
     # If user provided add-random-kimnums option, attempt to overwrite their
     # generator file

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     dest = args["destination"]
     overwrite = args["overwrite"]
     dry_run = args["dry_run"]
-    random_codes = args["add_random_kimnums"]
+    add_random_kimnums = args["add_random_kimnums"]
     generator_file = args["generator_file"]
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
@@ -565,7 +565,7 @@ if __name__ == "__main__":
 
     # If user provided add-random-kimnums option, attempt to overwrite their
     # generator file
-    if random_codes:
+    if add_random_kimnums:
         add_random_kimnum(root_dir, template_file_directory_path, generator_file)
 
     # Generate items

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -94,7 +94,7 @@ def createLogger(logfile, verbose):
         formatstr = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 
     logging.basicConfig(filename=logfile, level=loglevel, format=formatstr)
-    logger = logging.getLogger("testgenie")
+    logger = logging.getLogger("kimgenie")
     return logger
 
 
@@ -145,7 +145,7 @@ def generate_item(
         return f"{{{{ query({rendered}) }}}}"
 
     if logger is None:
-        logger = logging.getLogger("testgenie")
+        logger = logging.getLogger("kimgenie")
         nullhdlr = logging.NullHandler()
         logger.addHandler(nullhdlr)
 

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -433,6 +433,37 @@ def create_shared_arguments():
     return shared
 
 
+def create_tests_arguments(parse_tests):
+    parse_tests.add_argument(
+        "--test-driver",
+        type=str,
+        help=(
+            "Extended KIM ID of the Test Driver whose Tests you wish to "
+            "generate.  Either this option or the 'root-dir' option should be "
+            "given.  If this option is specified, the corresponding Test "
+            f"Driver directory must exist under {TDDIR}."
+        ),
+    )
+    parse_tests.add_argument(
+        "--root-dir",
+        type=str,
+        help="The directory that contains the template file directory and "
+        "generator file. Either this option must be supplied or the "
+        "'test-driver' option must be given.",
+    )
+
+
+def create_ref_data_arguments(parse_ref_data):
+    parse_ref_data.add_argument(
+        "root-dir",
+        type=str,
+        help=(
+            "The directory that contains the template file directory and "
+            "generator file.  May be an absolute or relative path."
+        ),
+    )
+
+
 def process_tests_root_dir_and_test_driver_options(root_dir, test_driver):
 
     if root_dir and test_driver:
@@ -473,32 +504,8 @@ if __name__ == "__main__":
     )
 
     # Custom options for each subaction
-    parse_tests.add_argument(
-        "--test-driver",
-        type=str,
-        help=(
-            "Extended KIM ID of the Test Driver whose Tests you wish to "
-            "generate.  Either this option or the 'root-dir' option should be "
-            "given.  If this option is specified, the corresponding Test "
-            f"Driver directory must exist under {TDDIR}."
-        ),
-    )
-    parse_tests.add_argument(
-        "--root-dir",
-        type=str,
-        help="The directory that contains the template file directory and "
-        "generator file. Either this option must be supplied or the "
-        "'test-driver' option must be given.",
-    )
-
-    parse_ref_data.add_argument(
-        "root-dir",
-        type=str,
-        help=(
-            "The directory that contains the template file directory and "
-            "generator file.  May be an absolute or relative path."
-        ),
-    )
+    create_tests_arguments(parse_tests)
+    create_ref_data_arguments(parse_ref_data)
 
     parse_tests.set_defaults(action="tests")
     parse_ref_data.set_defaults(action="ref-data")

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -12,8 +12,8 @@ template files.  The template files should be formatted to be processed with
 the Jinja2 python package.  The generation of an item takes place in stages:
 
   1. Grab the dictionary defined in a given line of the generator file
-  2. If a global template variables file is passed as input, add the
-     corresponding variables to the global template variable namespace used
+  2. If a global template variables string or file path is passed as input, add
+     the corresponding variables to the global template variable namespace used
      during the rendering process
   3. Render the kimspec.edn.genie file (which is required to exist) in the
      template file directory
@@ -390,22 +390,20 @@ def setup_logging(logfile, verbose):
 
 
 def update_global_template_vars(
-    global_template_vars, template_file_directory_path, global_variables_file
+    global_template_vars, template_file_directory_path, global_variables
 ):
     """Update global variables dict from file"""
-    if global_variables_file:
+    if global_variables:
         try:
             with open(
                 os.path.abspath(
-                    os.path.join(
-                        template_file_directory_path, "..", global_variables_file
-                    )
+                    os.path.join(template_file_directory_path, "..", global_variables)
                 ),
                 encoding="utf-8",
             ) as global_template_vars_fl:
                 global_template_vars.update(json.loads(global_template_vars_fl.read()))
         except IOError:
-            global_template_vars.update(json.loads(global_variables_file))
+            global_template_vars.update(json.loads(global_variables))
 
 
 def expand_tilde_to_home_dir(path_str):
@@ -490,7 +488,7 @@ def create_shared_arguments():
     )
 
     shared.add_argument(
-        "--global-variables-file",
+        "--global-variables",
         type=str,
         help="Additional JSON-formatted dictionary of global variables, as file or string",
     )
@@ -682,7 +680,7 @@ if __name__ == "__main__":
     generator_file = args["generator_file"]
     filename_prefix = args["filename_prefix"]
     filename_extension = args["filename_extension"]
-    global_variables_file = args["global_variables_file"]
+    global_variables = args["global_variables"]
     log_file = args["log_file"]
     verbose = args["verbose"]
     version = args["version"]
@@ -713,7 +711,7 @@ if __name__ == "__main__":
     # If the user specified a global variables file, update the global
     # variables defined thus far
     update_global_template_vars(
-        global_template_vars, template_file_directory_path, global_variables_file
+        global_template_vars, template_file_directory_path, global_variables
     )
 
     # Set up logger if necessary

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -75,7 +75,7 @@ TEDIR = os.path.join(cf.LOCAL_REPOSITORY_PATH, cf.item_subdir_names["te"])
 KIMSPEC_FILE = cf.CONFIG_FILE
 TEMPLATEDIR = "test_template"
 
-# The required argument 'testdriver' is required to be a valid KIM ID for a Test Driver
+# The required argument 'test_driver' is required to be a valid KIM ID for a Test Driver
 RE_TESTDRIVER = r"^(?:([_a-zA-Z][_a-zA-Z0-9]*?)__)?(TD)_([0-9]{12})(?:_([0-9]{3}))$"
 
 ##############################
@@ -199,8 +199,8 @@ def maketest(
                 template_intermediate = template_environment.get_template(filepath)
                 new_contents = template_intermediate.render(**template_variables)
 
-                # Now actually perform any queries that might be present and write the final rendered
-                # template to file
+                # Now actually perform any queries that might be present and
+                # write the final rendered template to file
                 template_final = jinja2.Environment(
                     loader=jinja2.BaseLoader
                 ).from_string(str(new_contents))
@@ -257,13 +257,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "testdriver",
+        "test-driver",
         type=str,
         help="Extended KIM ID of the Test Driver whose Tests you wish to generate",
     )
 
     parser.add_argument(
-        "--templatedir",
+        "--template-dir",
         type=str,
         default=TEMPLATEDIR,
         help="Directory containing the template files [default: {}]".format(
@@ -386,11 +386,11 @@ if __name__ == "__main__":
             logger = createLogger(args["logfile"], verbose=args["verbose"])
 
     # Before we do anything, check that the Test Driver supplied is a proper Extended ID
-    if not re.match(RE_TESTDRIVER, args["testdriver"]):
+    if not re.match(RE_TESTDRIVER, args["test_driver"]):
         print(
             "ERROR: {} is not a valid KIM ID for a Test Driver. Aborting "
             "Test generation.\n  See https://openkim.org/about-kim-ids/ "
-            "for information about KIM IDs.".format(args["testdriver"])
+            "for information about KIM IDs.".format(args["test_driver"])
         )
         exit(1)
 
@@ -411,9 +411,9 @@ if __name__ == "__main__":
     dest = re.sub("~", os.path.expanduser("~"), dest)
 
     # Find test_template directory
-    td_template_path = os.path.join(source, args["testdriver"], args["templatedir"])
+    td_template_path = os.path.join(source, args["test_driver"], args["template_dir"])
 
-    global_vars = {"TEST_DRIVER_NAME": args["testdriver"]}
+    global_vars = {"TEST_DRIVER_NAME": args["test_driver"]}
     global_vars["version"] = "{:03d}".format(args["version"])
 
     # Get global vars
@@ -447,7 +447,7 @@ if __name__ == "__main__":
                         "all instances of 'kimnum' if you wish to use "
                         "--add-random-kimnums. Aborting test "
                         "generation.".format(
-                            os.path.join(source, args["testdriver"], generator_file)
+                            os.path.join(source, args["test_driver"], generator_file)
                         )
                     )
                     sys.exit(1)

--- a/docker/config/tools/kimgenie
+++ b/docker/config/tools/kimgenie
@@ -177,13 +177,13 @@ def generate_item(
             item_name = template_variables["kimspec"][item_name_kimspec_key]
 
             # Create temporary directory
-            tmp_test_dir = os.path.join(tempdir, item_name)
-            shutil.copytree(template_file_directory_path, tmp_test_dir)
+            tmp_item_dir = os.path.join(tempdir, item_name)
+            shutil.copytree(template_file_directory_path, tmp_item_dir)
 
-            logger.info("BUILDING: {} @ {}".format(item_name, tmp_test_dir))
+            logger.info("BUILDING: {} @ {}".format(item_name, tmp_item_dir))
             logger.debug("Variable_dict: {}".format(template_variables))
 
-            for (basepath, _, files) in os.walk(tmp_test_dir):
+            for (basepath, _, files) in os.walk(tmp_item_dir):
                 for fl in files:
                     logger.debug("processing {}".format(fl))
                     filepath = os.path.join(basepath, fl)
@@ -233,27 +233,27 @@ def generate_item(
                     # Set permissions to match the corresponding template file
                     os.chmod(newfilepath, original_mode)
 
-            test_dest_name = os.path.join(dest, item_name)
+            item_dest_name = os.path.join(dest, item_name)
 
             if not dry_run:
                 # Now move the finished item directory to its final home
-                if os.path.isdir(test_dest_name):
-                    logger.info("Moving to {}".format(test_dest_name))
+                if os.path.isdir(item_dest_name):
+                    logger.info("Moving to {}".format(item_dest_name))
                     if overwrite:
-                        shutil.rmtree(test_dest_name)
-                        shutil.move(tmp_test_dir, test_dest_name)
+                        shutil.rmtree(item_dest_name)
+                        shutil.move(tmp_item_dir, item_dest_name)
                     else:
                         shutil.rmtree(tempdir)
                         raise OSError(
                             "Directory {} already exists! "
-                            "Aborting...".format(test_dest_name)
+                            "Aborting...".format(item_dest_name)
                         )
                 else:
-                    shutil.move(tmp_test_dir, test_dest_name)
+                    shutil.move(tmp_item_dir, item_dest_name)
 
                 return os.path.join(dest, item_name)
 
-            return test_dest_name
+            return item_dest_name
 
     except KeyboardInterrupt:
         sys.exit(1)
@@ -316,7 +316,7 @@ def add_random_kimnum(root_dir, template_file_directory_path, generator_file):
                     "a 'kimnum' key present in one or more of the "
                     "dictionaries in generator file {}. Please remove "
                     "all instances of 'kimnum' if you wish to use "
-                    "--add-random-kimnums. Aborting test "
+                    "--add-random-kimnums. Aborting item "
                     "generation.".format(os.path.join(root_dir, generator_file))
                 )
                 sys.exit(1)
@@ -389,7 +389,7 @@ def create_shared_arguments():
             "in which a 'kimnum' key (with a random kimcode as its corresponding value) is "
             "added to each dictionary contained within. Before this alteration is made, a "
             "check is performed to determine if there is already a 'kimnum' key present "
-            "in any of the dictionaries in the generator file and, if so, the entire test "
+            "in any of the dictionaries in the generator file and, if so, the entire item "
             "generation process is aborted and your generator file will not be overwritten."
         ),
     )
@@ -586,7 +586,7 @@ if __name__ == "__main__":
         for line in f:
             template_variables = global_template_vars.copy()
             template_variables.update(json.loads(line))
-            newtestpath = generate_item(
+            new_item_path = generate_item(
                 action,
                 template_file_directory_path,
                 template_variables=template_variables,
@@ -597,4 +597,4 @@ if __name__ == "__main__":
                 filename_extension=filename_extension,
                 logger=logger,
             )
-            print(newtestpath)
+            print(new_item_path)

--- a/docker/config/tools/kimitems
+++ b/docker/config/tools/kimitems
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-database
+++ b/docker/config/tools/pipeline-database
@@ -147,7 +147,7 @@ it.  This utility also allows you to:
 
 The local mongo database is stored at /pipeline/db/
 
-NOTE: The `kimitems` and `testgenie` utilities will always perform their queries
+NOTE: The `kimitems` and `kimgenie` utilities will always perform their queries
       to the remote OpenKIM database, even if you are using a local database.""",
         epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/docker/config/tools/pipeline-database
+++ b/docker/config/tools/pipeline-database
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-find-matches
+++ b/docker/config/tools/pipeline-find-matches
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-run-matches
+++ b/docker/config/tools/pipeline-run-matches
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-run-pair
+++ b/docker/config/tools/pipeline-run-pair
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-run-tests
+++ b/docker/config/tools/pipeline-run-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/tools/pipeline-run-verification-checks
+++ b/docker/config/tools/pipeline-run-verification-checks
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 reserved.
 
 This software may be distributed as-is, without modification.

--- a/docker/config/utils/bashcompletion
+++ b/docker/config/utils/bashcompletion
@@ -485,7 +485,7 @@ _complete_kimgenie(){
     opts="tests ref-data"
 
     shared_opts="-h --help -v --verbose --root-dir --template-dir --generator-file
-         --global-variables-file --dry-run --destination --overwrite --add-random-kimnums
+         --global-variables --dry-run --destination --overwrite --add-random-kimnums
          --filename-prefix --filename-extension --version --log-file"
 
     tests_opts=${shared_opts}" --test-driver"

--- a/docker/config/utils/bashcompletion
+++ b/docker/config/utils/bashcompletion
@@ -18,6 +18,31 @@ _queryall(){
     echo ${temp//,/} # Remove commas
 }
 
+_glob_on_dirs(){
+    cwd=`pwd`
+    part=$1
+
+    if [[ $part == /* ]] || [[ $part == ~* ]]; then
+        # TODO: Add recursive directory completion.  The challenge of this is
+        # that you can't simply find the first match and finish the completion;
+        # if the first match is itself a directory, you want to traverse down
+        # to it and start matching on its contents rather than simply ending
+        # the completion process
+        :
+    else
+        if [ ! -n "$part" ]; then
+            # part was null
+            temp=$(find ${cwd}/* -maxdepth 0 -type d -printf "%f " 2>/dev/null)
+            echo $temp
+        else
+            # part was not null
+            temp=$(find ${cwd}/* -maxdepth 0 -type d -name "$part*" -printf "%f " 2>/dev/null)
+            echo $temp
+        fi
+    fi
+
+}
+
 _getall(){
     folders=$1
     part=$2
@@ -450,22 +475,51 @@ _complete_pipeline_runpair(){
     fi
 }
 
-_complete_testgenie(){
-    local cur prev
+_complete_kimgenie(){
+    local cur prev opts
     COMPREPLY=()
+    allwords="${COMP_WORDS[@]}"
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-h --help -v --verbose --templatedir --source --generator-file
-         --global-variables --dry-run --destination --overwrite --add-random-kimnums
-         --filename-prefix --filename-extension --version --logfile"
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-        return 0
-    else
-        local objs=$(_getall "td" "$cur")
-        COMPREPLY=( $(compgen -W "${objs}" -- ${cur}) )
-        return 0
+    opts="tests ref-data"
+
+    shared_opts="-h --help -v --verbose --root-dir --template-dir --generator-file
+         --global-variables --dry-run --destination --overwrite --add-random-kimnums
+         --filename-prefix --filename-extension --version --log-file"
+
+    tests_opts=${shared_opts}" --test-driver"
+
+    if [[ $allwords =~ kimgenie.*tests ]]; then
+        if [[ $cur == -* ]]; then
+            COMPREPLY=( $(compgen -W "${tests_opts}" -- ${cur}) )
+            return 0
+        else
+            # If we're the first word after the --test-driver flag, complete on
+            # Test Drivers in the local repository
+            if [[ $prev == --test-driver ]]; then
+                local objs=$(_getall "td" "$cur")
+                COMPREPLY=( $(compgen -W "${objs}" -- ${cur}) )
+                return 0
+            fi
+        fi
+    elif [[ $allwords =~ kimgenie.*ref-data.* ]]; then
+        if [[ $cur == -* ]]; then
+            COMPREPLY=( $(compgen -W "${shared_opts}" -- ${cur}) )
+            return 0
+        else
+            local matching_dirs=$(_glob_on_dirs "$cur")
+            COMPREPLY=( $(compgen -W "${matching_dirs}" -- ${cur}) )
+            return 0
+        fi
+    elif [[ $allwords =~ kimgenie ]]; then
+        if [[ $cur == -* ]]; then
+            COMPREPLY=( $(compgen -W "-h --help" -- ${cur}) )
+            return 0
+        else
+            COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            return 0
+        fi
     fi
 }
 
@@ -476,4 +530,4 @@ complete -F _complete_pipeline_findmatches pipeline-find-matches
 complete -F _complete_pipeline_runmatches pipeline-run-matches
 complete -F _complete_pipeline_runtests pipeline-run-tests
 complete -F _complete_pipeline_runverificationchecks pipeline-run-verification-checks
-complete -F _complete_testgenie testgenie
+complete -F _complete_kimgenie kimgenie

--- a/docker/config/utils/bashcompletion
+++ b/docker/config/utils/bashcompletion
@@ -485,7 +485,7 @@ _complete_kimgenie(){
     opts="tests ref-data"
 
     shared_opts="-h --help -v --verbose --root-dir --template-dir --generator-file
-         --global-variables --dry-run --destination --overwrite --add-random-kimnums
+         --global-variables-file --dry-run --destination --overwrite --add-random-kimnums
          --filename-prefix --filename-extension --version --log-file"
 
     tests_opts=${shared_opts}" --test-driver"

--- a/docker/config/utils/bashcompletion
+++ b/docker/config/utils/bashcompletion
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/kimgenie
+++ b/docker/config/utils/kimgenie
@@ -7,7 +7,7 @@
 #
 ROOT_LOC="/pipeline"
 PYTHON_LOC="/usr/bin/python3"
-UTIL_LOC=${ROOT_LOC}"/tools/testgenie"
+UTIL_LOC=${ROOT_LOC}"/tools/kimgenie"
 
 # Grab the arguments passed to this function
 args="$@"

--- a/docker/config/utils/kimgenie
+++ b/docker/config/utils/kimgenie
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/kimitems
+++ b/docker/config/utils/kimitems
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-database
+++ b/docker/config/utils/pipeline-database
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-find-matches
+++ b/docker/config/utils/pipeline-find-matches
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-run-matches
+++ b/docker/config/utils/pipeline-run-matches
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-run-pair
+++ b/docker/config/utils/pipeline-run-pair
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-run-tests
+++ b/docker/config/utils/pipeline-run-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/config/utils/pipeline-run-verification-checks
+++ b/docker/config/utils/pipeline-run-verification-checks
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2014-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/git/Dockerfile
+++ b/docker/git/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone -q https://github.com/openkim/numdifftools -b master ${PACKAGE_DIR
 RUN git clone -q https://github.com/openkim/kim-python-utils -b master ${PACKAGE_DIR}/kim-python-utils \
   && cd ${PACKAGE_DIR}/kim-python-utils \
   && git checkout 0fdeaf2c0ab4704f1789c57c4abe3026a55ff03b
-RUN git clone -q https://github.com/lammps/lammps -b patch_30Jul2021 ${PACKAGE_DIR}/lammps
+RUN git clone -q https://github.com/lammps/lammps -b stable_23Jun2022 ${PACKAGE_DIR}/lammps
 RUN git clone -q https://gitlab.com/openkim/ase -b user-species ${PACKAGE_DIR}/ase \
   && cd ${PACKAGE_DIR}/ase \
   && git checkout 94c6ad70814965408a2977f7428b62271988619c

--- a/docker/git/Dockerfile
+++ b/docker/git/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2018-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/git/Dockerfile
+++ b/docker/git/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone -q https://github.com/openkim/numdifftools -b master ${PACKAGE_DIR
   && cd ${PACKAGE_DIR}
 RUN git clone -q https://github.com/openkim/kim-python-utils -b master ${PACKAGE_DIR}/kim-python-utils \
   && cd ${PACKAGE_DIR}/kim-python-utils \
-  && git checkout 0fdeaf2c0ab4704f1789c57c4abe3026a55ff03b
+  && git checkout e4e21b202264373a9f33dfc47b6e05c0af625950
 RUN git clone -q https://github.com/lammps/lammps -b stable_23Jun2022 ${PACKAGE_DIR}/lammps
 RUN git clone -q https://gitlab.com/openkim/ase -b user-species ${PACKAGE_DIR}/ase \
   && cd ${PACKAGE_DIR}/ase \

--- a/docker/git/Dockerfile
+++ b/docker/git/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone -q https://github.com/openkim/kim-python-utils -b master ${PACKAGE
 RUN git clone -q https://github.com/lammps/lammps -b stable_23Jun2022 ${PACKAGE_DIR}/lammps
 RUN git clone -q https://gitlab.com/openkim/ase -b user-species ${PACKAGE_DIR}/ase \
   && cd ${PACKAGE_DIR}/ase \
-  && git checkout 94c6ad70814965408a2977f7428b62271988619c
+  && git checkout e00c8da0f84fb3a726c411f7ef2792241434c9a3
 RUN git clone -q https://gitlab.com/micronano_public/MDpp -b release ${PACKAGE_DIR}/MD++ \
   && cd ${PACKAGE_DIR}/MD++ \
   && git checkout f7d64a7720a4bc1602371a128c8db7779fcf8dcb

--- a/docker/git/Dockerfile
+++ b/docker/git/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p ${PACKAGE_DIR}
 RUN apt-get -qq update
 RUN apt-get install --no-install-recommends -qqy ca-certificates
 RUN apt-get install --no-install-recommends -qqy git
-RUN git clone -q https://github.com/openkim/numdifftools -b openkim-master ${PACKAGE_DIR}/numdifftools \
+RUN git clone -q https://github.com/openkim/numdifftools -b master ${PACKAGE_DIR}/numdifftools \
   && cd ${PACKAGE_DIR}/numdifftools \
   && git checkout a53debb144ed02c5c6eb74d5c18d53058259f27c \
   && cd ${PACKAGE_DIR}

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -37,7 +37,7 @@ RUN ${PIP} install setuptools==54.0.0
 RUN ${PIP} install packaging==20.9
 RUN ${PIP} install Jinja2==2.11.3
 RUN ${PIP} install edn_format==0.7.5
-RUN ${PIP} install kim-edn==1.2.0
+RUN ${PIP} install kim-edn==1.3.1
 RUN ${PIP} install kim-property==2.4.0
 RUN ${PIP} install kim-query==3.0.0
 RUN ${PIP} install simplejson==3.17.2

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -35,6 +35,7 @@ ARG PYTHON=python3
 RUN ${PIP} install wheel==0.36.2
 RUN ${PIP} install setuptools==54.0.0
 RUN ${PIP} install packaging==20.9
+RUN ${PIP} install markupsafe==2.0.1
 RUN ${PIP} install Jinja2==2.11.3
 RUN ${PIP} install edn_format==0.7.5
 RUN ${PIP} install kim-edn==1.3.1

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2018-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.

--- a/docker/install/Dockerfile
+++ b/docker/install/Dockerfile
@@ -69,7 +69,7 @@ RUN cd ${PACKAGE_DIR}/MD++ \
 #########################################
 ## KIM API
 #########################################
-ARG KIM_API_VER=2.2.1
+ARG KIM_API_VER=2.3.0
 ARG KIM_API_PACKAGE=kim-api-${KIM_API_VER}
 ARG KIM_API_ARCHIVE_TXZ=${KIM_API_PACKAGE}.txz
 RUN cd ${PACKAGE_DIR} \
@@ -105,7 +105,7 @@ RUN apt-get update -qq \
 ## kimpy
 #########################################
 # NOTE: Must be installed after KIM API
-RUN ${PIP} install kimpy==2.0.0
+RUN ${PIP} install kimpy==2.0.1
 
 #########################################
 ## LAMMPS

--- a/docker/sys/Dockerfile
+++ b/docker/sys/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, Regents of the University of Minnesota. All rights
+# Copyright (c) 2018-2022, Regents of the University of Minnesota. All rights
 # reserved.
 #
 # This software may be distributed as-is, without modification.


### PR DESCRIPTION
In addition to a number of older changes Dan made to testgenie (formerly kimgenie) and bash completion, there are several relevant software updates that have been incorporated:
  
  Update kim-edn version 1.2.0->1.3.1
  Update branch name of numdifftools openkim-master --> master
  Update lammps to stable_23Jun2022
  Update ASE commit to e00c8da0f84fb3a726c411f7ef2792241434c9a3
  Update kim-python-utils commit to e4e21b202264373a9f33dfc47b6e05c0af625950
  Update KIM API to 2.3.0, and Update kimpy to 2.0.1 for compatibility
  Version pin markupsafe==2.0.1 (avoids breaking kimitems, jinja2 dependency)