### PR TITLE
Fixed typo in matching logic

### DIFF
--- a/docker/config/excerpts/matching.py
+++ b/docker/config/excerpts/matching.py
@@ -252,7 +252,7 @@ def run_compatibility_matching_models_match(runner, subject):
             # with the runner's "matching-models" list.  Note that
             # 'run-compatibility' is completely ignored in this case
             match, mismatch_info = simulator_potential_hierarchy_match(
-                runner.simulator_potential, subject.simulator_potential
+                runner.matching_models, subject.simulator_potential
             )
 
     return match, mismatch_info


### PR DESCRIPTION
@brendonwaters @dskarls , I think this is a straightforward typo that I fixed, right? Tests don't have a field "simulator-potential" in their kimspec.

If so, can you also double check the production pipeline matching code to make sure this isn't happening there too?