### PR TITLE
minimal changes to allow changing database path

### DIFF
--- a/docker/config/excerpts/default-environment
+++ b/docker/config/excerpts/default-environment
@@ -18,6 +18,7 @@ PIPELINE_VM_MODE=True
 
 LOG_DIR=/pipeline/logs
 LOCAL_REPOSITORY_PATH=/home/openkim/
+LOCAL_DATABASE_PATH=/pipeline/db
 USE_FULL_ITEM_NAMES_IN_REPO=True
 
 # parent directory where things are run by default

--- a/docker/config/excerpts/default-environment
+++ b/docker/config/excerpts/default-environment
@@ -24,9 +24,6 @@ USE_FULL_ITEM_NAMES_IN_REPO=True
 # parent directory where things are run by default
 WORKER_RUNNING_PATH=/tmp
 
-# We install MD/MO/SM to the KIM API user collection
-KIM_API_USER_COLLECTION=/home/openkim/.kim-api/
-
 # types of files that are expected at any one time, should be global
 OUTPUT_DIR=output
 TEST_EXECUTABLE=runner

--- a/docker/config/excerpts/mongodb.py
+++ b/docker/config/excerpts/mongodb.py
@@ -15,8 +15,9 @@ from . import util
 from . import kimobjects
 from .kimcodes import parse_kim_code, isextendedkimid, isuuid
 
+PIPELINE_LOCAL_DB_PATH = cf.LOCAL_DATABASE_PATH
 
-client = MontyClient("/pipeline/db", cache_modified=0)
+client = MontyClient(PIPELINE_LOCAL_DB_PATH, cache_modified=0)
 db = client.db
 
 PATH_RESULT = cf.LOCAL_REPOSITORY_PATH

--- a/docker/config/instructions/README.txt
+++ b/docker/config/instructions/README.txt
@@ -258,9 +258,9 @@ Section IV. Running your content
     Whereas by default all of the queries in the pipeline.stdin.tpl files of
     the Tests are directed to query.openkim.org, if you issue
     `pipeline-database set local`, they will all be directed to a local
-    database that is stored on disk at /pipeline/db/.  Assuming this has been
-    done (the selection persists between starts/stops of the container), you
-    can then proceed to run all of the Tests in a dependency hierarchy in
+    database that is stored on disk at /pipeline/db/ by default. Assuming this 
+    has been done (the selection persists between starts/stops of the container), 
+    you can then proceed to run all of the Tests in a dependency hierarchy in
     order.  In the example above, you would use `pipeline-run-pair` to run your
     Model or Simulator Model against the fcc Al lattice constant Test and then
     use it to run against the fcc Al elastic constants Test.^
@@ -575,7 +575,7 @@ Section VI. Command-line utilities
      (2) import/export a local database using the mongdo db extended json format
      (3) restore/dump a local database using the bson (binary json) format
 
-    The local mongo database is stored at /pipeline/db/
+    The local mongo database is stored at /pipeline/db/ by default
 
     NOTE: The `kimitems` and `kimgenie` utilities will always perform their queries
           to the remote OpenKIM database, even if you are using a local database.
@@ -599,7 +599,7 @@ Section VI. Command-line utilities
 
         pipeline-database delete [-f]
 
-      Deletes the local mongo database, which is stored at /pipeline/db/
+      Deletes the local mongo database, which is stored at /pipeline/db/ by default
 
       Options
       -------

--- a/docker/config/tools/pipeline-database
+++ b/docker/config/tools/pipeline-database
@@ -18,7 +18,7 @@ from bson.errors import InvalidBSON
 
 import excerpts.config as cf
 
-PIPELINE_LOCAL_DB_PATH = "/pipeline/db/"
+PIPELINE_LOCAL_DB_PATH = cf.LOCAL_DATABASE_PATH
 
 PIPELINE_ENV_HEADER = """#!/bin/bash
 #==============================================
@@ -145,7 +145,7 @@ it.  This utility also allows you to:
  (2) import/export a local database using the mongdo db extended json format
  (3) restore/dump a local database using the bson (binary json) format
 
-The local mongo database is stored at /pipeline/db/
+The local mongo database is stored at cf.LOCAL_DATABASE_PATH (/pipeline/db/ by default)
 
 NOTE: The `kimitems` and `kimgenie` utilities will always perform their queries
       to the remote OpenKIM database, even if you are using a local database.""",


### PR DESCRIPTION
This minimal change allows changing the path of the local database. This is necessary to allow the Docker image to be exported to an operational Singularity container that is able to use the local database (since singularity uses the host filesystem and therefore cannot write to /pipeline/db/). So far, `kimitems install` and `pipeline-run-pair` is confirmed working using Singularity. All other necessary paths should be able to be set using a custom file specified with the `PIPELINE_ENVIRONMENT_FILE` environment variable passed into the container.